### PR TITLE
[codex] Fix primary key guidance in model builder

### DIFF
--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -172,7 +172,7 @@ Write with `mode: "extension"` (shared model layer). To delete a file, send empt
 
 ## Writing Views
 
-> **Every view MUST have a `primary_key: true` dimension.** Without a primary key, queries that join to this view will produce fanout errors or incorrect aggregations. Use the table's natural unique identifier (e.g., `id`, `order_id`, `user_id`). If the table has no single unique column, create a composite key with a SQL expression: `sql: ${schema_name} || '-' || ${table_name}`.
+> **Every view that participates in joins MUST have a real `primary_key: true` dimension.** Without a genuine row-unique primary key, queries that join to this view can produce fanout errors or incorrect aggregations. Use the table's natural unique identifier (e.g., `id`, `order_id`, `user_id`). If no single column is unique, build a composite key from row-level columns that are jointly unique, for example `sql: ${order_id} || '-' || ${line_number}`. If you cannot define a row-unique expression, do not mark a dimension as `primary_key: true` yet; fix the grain first or avoid joining the view until a real key exists.
 
 ### Basic View
 


### PR DESCRIPTION
## Summary
- replace the invalid constant-expression fallback primary key example in `skills/omni-model-builder/SKILL.md`
- clarify that composite keys must be built from row-level columns that are jointly unique
- state explicitly that a dimension should not be marked `primary_key: true` until a real row-unique expression exists

## Why
The previous guidance suggested `sql: ${schema_name} || '-' || ${table_name}` as a composite key fallback. That expression is constant for every row in a view, so it is not a valid primary key and can lead to incorrect join behavior and aggregations.

## Impact
This makes the model-builder guidance safer to copy and reduces the risk of users introducing silent fanout problems when defining joinable views.

## Validation
- ran `git diff --check -- skills/omni-model-builder/SKILL.md`
- reviewed the final diff to ensure the guidance now describes only row-unique key patterns

Closes #4