### PR TITLE
[codex] Add contributing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,122 +1,34 @@
 # Contributing with Agents
 
-This file provides guidance for AI agents (Claude Code, Cursor, Codex, etc.) working in this repository. It covers skill authoring conventions, validation requirements, plugin registration, and PR workflow. Read this before making changes.
+This file contains agent-specific operating instructions for this repository. Follow [CONTRIBUTING.md](CONTRIBUTING.md) for contributor policy: skill and agent authoring, validation, evals, versioning, changelog entries, and PR expectations.
 
-## Repository Overview
+## Before Editing
 
-```
-omni-agent-skills/
-├── skills/            # One directory per skill, each with a SKILL.md
-├── agents/            # Agent definitions (*.md with frontmatter)
-├── rules/             # Cursor .mdc rules (shared reference for other platforms)
-├── evals/             # Eval harness for omni-ai-eval skill testing
-├── .claude-plugin/    # Claude Code plugin metadata (plugin.json, marketplace.json)
-└── .cursor-plugin/    # Cursor plugin metadata
-```
+- Read the relevant existing skill, agent, rule, README, or eval file before changing it.
+- Keep edits scoped to the requested workflow and the repository's current patterns.
+- Use `rg`/`rg --files` for repository searches.
+- Respect dirty worktrees. Do not revert changes you did not make.
 
-Skills are loaded by agents when a user's request matches the `description` field in `SKILL.md`. Agents in `agents/` are invoked directly by name (e.g., `@omni-analyst`). Both are auto-discovered from their directories once the plugin is installed — no manual registration is required.
+## Repository Routing
 
-## Skill Authoring
+- New general Omni skills go under `skills/`.
+- New integration-specific skills go under `skills/omni-integrations/skills/`.
+- Agent definitions live in `agents/`.
+- Cursor rules live in `rules/`.
+- Evals for a skill live under `skills/<skill-name>/evals/`; the root `evals/` directory contains runner tooling.
 
-Each skill lives in its own directory under `skills/` and must contain a `SKILL.md`.
+Skills and agents are auto-discovered from their directories. Do not add manifest registration for individual skills or agents.
 
-### SKILL.md Frontmatter
+## Command and Content Rules
 
-```yaml
----
-name: skill-name
-description: One paragraph description of what this skill does and when to use it. Include natural-language trigger phrases — this is what the agent reads to decide whether to load the skill.
----
-```
+- Do not hallucinate CLI flags. Run `omni <command> --help` before documenting or relying on a command shape.
+- Use Omni CLI examples where the CLI supports the operation.
+- When REST is necessary, use the bearer-token pattern documented in `CONTRIBUTING.md`.
+- Do not copy Cursor rule content into skills or agent definitions. Link to rules as reference material when needed.
 
-The `description` field is the primary routing signal. Write it to match how users naturally ask for this work. Include verb phrases like "use this skill whenever someone wants to..." and list representative trigger phrases.
+## Validation and Release
 
-### SKILL.md Body Conventions
-
-Start with **Prerequisites** (Omni CLI check, env vars) and **Discovering Commands** (`omni <command> --help` examples). Organize the rest around the skill's domain — look at existing skills for patterns. Where there is non-obvious behavior, a bug, or a constraint an agent would otherwise learn the hard way, document it under a **Known Issues & Safe Defaults** section near the top.
-
-Use CLI examples over raw API calls where the Omni CLI supports the operation. When using the REST API directly, include the auth header pattern (`-H "Authorization: Bearer $OMNI_API_TOKEN"`).
-
-### Skill Directory Structure
-
-```
-skills/my-skill/
-├── SKILL.md          # Required
-├── references/       # Optional: reference docs, schemas, example responses
-└── evals/            # Optional: eval test cases for this skill
-```
-
-## Agent Authoring
-
-Agent definitions live in `agents/` as Markdown files with YAML frontmatter.
-
-```yaml
----
-name: agent-name
-description: When to delegate to this agent. Be specific — this routes requests at the agent level.
----
-```
-
-Agent bodies should define:
-- **Workflow** — numbered steps the agent follows, in order
-- **Conventions** — behavioral defaults (e.g., default granularity, output format)
-- **Skills You Should Use** — explicit list of skill names this agent relies on
-
-Agents orchestrate skills — they do not duplicate skill content. If an agent needs to run a query, it invokes `omni-query`. Do not copy CLI examples or API patterns from skills into agent definitions.
-
-## Plugins
-
-Skills and agents are auto-discovered from `skills/` and `agents/` — no manifest registration needed. The plugin manifests (`.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and their `marketplace.json` counterparts) carry only plugin-level metadata: name, version, description, author.
-
-This repo ships two plugins: `omni-analytics` at the root, and `omni-integrations` rooted at `skills/omni-integrations/`. Both are listed as separate entries in the root `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json`. New integrations skills go under `skills/omni-integrations/skills/`; new general skills go under `skills/`.
-
-## Validation
-
-Before opening a PR, validate that your skill or agent works against a real Omni instance:
-
-1. **Install the Omni CLI** if not already present — see [README Setup](README.md#setup)
-2. **Configure credentials**:
-   ```bash
-   # Show available profiles and select the appropriate one
-   omni config show
-   # If multiple profiles exist, pick one and switch:
-   omni config use <profile-name>
-   ```
-3. **Run the key CLI commands** referenced in your skill — verify they succeed and return expected output
-4. **For query or model skills**: run at least one realistic end-to-end operation (e.g., `omni query run`, `omni models yaml-create`)
-5. **For content skills**: read back the created artifact to confirm it was written correctly — dashboard updates are full replacements, so verify nothing was lost
-
-Do not mark a PR ready for review if the skill has only been tested with mocked or fabricated API responses.
-
-### Evals
-
-The `evals/` directory contains the BenchFlow-based skill eval runner. If you add or modify query-related skills, add BenchFlow `cases` under `skills/<skill-name>/evals/evals.json`. See `evals/README.md` for the runner workflow and `evals/SETUP.md` for the shared Omni instance setup.
-
-## Versioning
-
-Bump the plugin version when **a user who already has the plugin installed would get different behavior after updating**. Ask: would an existing install change? If yes, bump. If no, skip it.
-
-Examples that warrant a bump:
-- A skill's `description` changed (affects when the skill loads)
-- A skill's workflow, CLI commands, or defaults changed (affects what the agent does)
-- A new skill or agent was added
-
-Examples that do not warrant a bump:
-- `AGENTS.md`, `README.md`, `CHANGELOG.md` — not loaded by the agent runtime
-- Files in `evals/` or `references/` subdirectories — contributor tooling, not agent content
-- Reformatting or rewording that doesn't change agent behavior
-
-For the mechanics — which files to update, PATCH/MINOR/MAJOR breakdown, and changelog format — follow the [Versioning and Changelog](README.md#versioning-and-changelog) section of the README.
-
-## PR Checklist
-
-- [ ] SKILL.md frontmatter has a `name` and a `description` that routes correctly
-- [ ] New skills go under the correct plugin (`skills/` for general, `skills/omni-integrations/skills/` for integrations)
-- [ ] Skill validated end-to-end against a real Omni instance
-- [ ] Eval cases added or updated if the change affects query behavior
-- [ ] If skill or agent content changed: version bumped in all affected plugin manifests and `CHANGELOG.md` updated
-
-## What to Avoid
-
-- **Don't hallucinate CLI flags** — use `omni <command> --help` to discover real flags before writing skill content
-- **Don't copy rules content into skills** — `omni-api-conventions` and `omni-yaml-conventions` are reference rules; link to them instead of duplicating
+- Validate behavior-changing skill or agent updates against a real Omni instance before marking the work ready.
+- Add or update BenchFlow eval cases when query-related behavior changes.
+- If distributed skill or agent behavior changes, update the affected plugin versions and `CHANGELOG.md` in the same PR.
+- Documentation-only changes to `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `CHANGELOG.md`, `evals/`, or `references/` usually do not need a version bump unless they change agent runtime behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,183 @@
+# Contributing to Omni Analytics Agent Skills
+
+This guide is the source of truth for contributor-facing policy: repository layout, skill and agent authoring, validation, evals, versioning, changelog entries, and PR expectations. The README is for users installing and using the repo; `AGENTS.md` is for agent-specific operating instructions; `evals/README.md` owns eval runner mechanics.
+
+## Repository Layout
+
+```text
+omni-agent-skills/
+├── skills/            # omni-analytics skills; one directory per skill
+├── skills/omni-integrations/
+│   └── skills/        # omni-integrations skills
+├── agents/            # Agent definitions (*.md with frontmatter)
+├── rules/             # Cursor .mdc rules
+├── evals/             # BenchFlow eval harness and shared setup docs
+├── .claude-plugin/    # Claude Code plugin metadata
+├── .cursor-plugin/    # Cursor plugin metadata
+├── CHANGELOG.md
+├── README.md
+└── AGENTS.md
+```
+
+New general Omni skills go under `skills/`. New integration-specific skills go under `skills/omni-integrations/skills/`. Skills, agents, and Cursor rules are auto-discovered from their directories; plugin manifests carry plugin-level metadata and version information only.
+
+## Setup
+
+Install and configure the Omni CLI before validating skill behavior:
+
+```bash
+omni config show
+omni config use <profile-name>
+```
+
+If no profiles exist, run `omni config init`. Some workflows can also use explicit `--base-url "$OMNI_BASE_URL" --token "$OMNI_API_TOKEN"` flags, but examples should prefer the CLI profile flow unless the workflow specifically needs environment fallback.
+
+Use a safe development environment. Prefer non-production data when testing modeling, content, admin, or eval workflows.
+
+## Skill Authoring
+
+Each skill lives in its own directory and must contain `SKILL.md` with YAML frontmatter:
+
+```yaml
+---
+name: skill-name
+description: One paragraph description of what this skill does and when to use it. Include natural-language trigger phrases.
+---
+```
+
+The `description` is the primary routing signal. Write it to match how users naturally ask for the work, using phrases such as "Use this skill whenever someone wants to..." and representative trigger phrases.
+
+Start the body with **Prerequisites** and **Discovering Commands** sections. Use Omni CLI examples where the CLI supports the operation. When REST is necessary, include the auth header pattern:
+
+```bash
+-H "Authorization: Bearer $OMNI_API_TOKEN"
+```
+
+Put non-obvious constraints, current bugs, and safe defaults near the top under **Known Issues & Safe Defaults** so agents see them before workflow details.
+
+Supporting material belongs beside the skill in focused subdirectories such as `references/`, `evals/`, `scripts/`, or `assets/`. Keep `SKILL.md` references shallow and relative to the skill root.
+
+## Agent Authoring
+
+Agent definitions live in `agents/` as Markdown files with YAML frontmatter:
+
+```yaml
+---
+name: agent-name
+description: When to delegate to this agent. Be specific.
+---
+```
+
+Agent bodies should define:
+
+- **Workflow**: numbered steps the agent follows
+- **Conventions**: behavioral defaults, output format, and confirmation points
+- **Skills You Should Use**: explicit companion skills
+
+Agents orchestrate skills. Do not duplicate skill examples, CLI patterns, or API payloads inside agent definitions. If an agent needs to run a query, it should invoke `omni-query`; if it needs to modify model YAML, it should invoke `omni-model-builder`.
+
+## Rule Authoring
+
+Rules in `rules/` are Cursor-specific `.mdc` files. Keep them narrowly scoped to stable conventions that should be available in Cursor without loading a skill.
+
+Do not copy rule content into skills. Link to rules as shared reference material when needed.
+
+## Validation
+
+Before opening a PR that changes skill or agent behavior, validate against a real Omni instance:
+
+1. Install and configure the Omni CLI.
+2. Run the key CLI commands referenced in the changed skill or agent.
+3. For query or model skills, run at least one realistic end-to-end operation, such as `omni query run` or `omni models yaml-create`.
+4. For content skills, read back the created or updated artifact. Dashboard updates are full replacements, so verify nothing was lost.
+5. For admin changes, verify permissions and read back the changed user, group, schedule, permit, or connection state where the CLI supports it.
+
+Do not mark a PR ready for review if the behavior has only been tested with mocked or fabricated API responses.
+
+Run `git diff --check` before requesting review.
+
+## Evals
+
+The root `evals/` directory is contributor tooling, not a distributed skill package. `evals/README.md` owns BenchFlow setup, runner commands, reset flows, fixture notes, and export mechanics.
+
+If you add or modify query-related skill behavior, add or update BenchFlow `cases` under the affected skill:
+
+```text
+skills/<skill-name>/evals/evals.json
+```
+
+Use the shared eval instance setup in `evals/SETUP.md` when a case depends on mutable Omni fixtures.
+
+## Versioning and Changelog
+
+Bump the affected plugin version when a user who already has the plugin installed would get different behavior after updating.
+
+Examples that warrant a bump:
+
+- a skill `description` changes, affecting when it loads
+- a skill or agent workflow, CLI command, API payload, or default changes
+- a new skill or agent is added
+- plugin metadata that users see changes
+
+Examples that usually do not warrant a bump:
+
+- `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, or `CHANGELOG.md` only
+- files in `evals/` or `references/` only
+- reformatting or rewording that does not change agent behavior
+
+Use semantic versioning:
+
+| Change type | Version component |
+|---|---|
+| Bug fixes, clarifications, doc corrections | `PATCH` |
+| New skills, new features, behavior changes | `MINOR` |
+| Breaking changes to existing skill behavior | `MAJOR` |
+
+Only bump the plugin whose behavior changed. A fix to `omni-integrations` does not require bumping `omni-analytics`.
+
+Keep duplicated version metadata in sync:
+
+- `omni-analytics`: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, `.cursor-plugin/marketplace.json`
+- `omni-integrations`: `skills/omni-integrations/.claude-plugin/plugin.json`, `skills/omni-integrations/.cursor-plugin/plugin.json`, `.claude-plugin/marketplace.json` (`omni-integrations` entry), `.cursor-plugin/marketplace.json` (`omni-integrations` entry)
+
+Document user-visible changes in `CHANGELOG.md` under the affected version. Use `Added`, `Changed`, and `Fixed` sections. The date should be the release date, not necessarily the commit date.
+
+```markdown
+## [1.3.0] - YYYY-MM-DD
+
+### omni-analytics
+
+**Added**
+- Description of new capability
+
+**Changed**
+- Description of behavior change
+
+**Fixed**
+- Description of bug fix
+```
+
+Version bumps and changelog entries should be included in the same PR as the behavior change, not batched separately after the fact.
+
+## PR Checklist
+
+- [ ] Skill or agent frontmatter routes correctly
+- [ ] New skills are under the correct plugin directory
+- [ ] CLI commands and flags were checked with `omni <command> --help` where relevant
+- [ ] Behavior was validated end-to-end against a real Omni instance where relevant
+- [ ] Eval cases were added or updated if query behavior changed
+- [ ] Affected plugin manifests were version bumped if distributed behavior changed
+- [ ] `CHANGELOG.md` was updated if distributed behavior changed
+- [ ] `git diff --check` passes
+
+## What to Avoid
+
+- Do not hallucinate CLI flags. Use `omni <command> --help` before documenting commands.
+- Do not prefer raw API examples when the Omni CLI supports the operation.
+- Do not duplicate rule content in skills or agent definitions.
+- Do not add a manifest registration step for skills or agents; directories are auto-discovered.
+- Do not mark real-instance validation complete when only mocked responses were used.
+
+## License
+
+By contributing to this repository, you agree that your contributions will be licensed under the same license as the project.

--- a/README.md
+++ b/README.md
@@ -478,51 +478,7 @@ Status labels use `🟢 Pass`, `🟡 Warn`, `🔴 Fail`, and `⚫ Error`.
 
 ## Contributing
 
-Contributions welcome! This is the single source of truth for all Omni Analytics agent skills. Please open an issue or PR.
-
-### Versioning and Changelog
-
-Use semantic versioning for published plugin changes. If you change distributed plugin behavior or metadata and do not bump the affected versions, existing installs may not pick up the update cleanly.
-
-**When to bump:**
-
-| Change type | Version component |
-|---|---|
-| Bug fixes, clarifications, doc corrections | `PATCH` (e.g. `1.2.0` → `1.2.1`) |
-| New skills, new features, behavior changes | `MINOR` (e.g. `1.2.0` → `1.3.0`) |
-| Breaking changes to existing skill behavior | `MAJOR` (e.g. `1.2.0` → `2.0.0`) |
-
-Only bump the plugin(s) whose behavior changed. A fix to `omni-integrations` does not require bumping `omni-analytics`.
-
-**Which files to update:**
-
-This repo currently duplicates version metadata across `plugin.json` and `marketplace.json`. Until that is centralized, keep all affected version fields in sync:
-
-- `omni-analytics`: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, `.cursor-plugin/marketplace.json`
-- `omni-integrations`: `skills/omni-integrations/.claude-plugin/plugin.json`, `skills/omni-integrations/.cursor-plugin/plugin.json`, `.claude-plugin/marketplace.json` (omni-integrations entry), `.cursor-plugin/marketplace.json` (omni-integrations entry)
-
-**Changelog format:**
-
-Document all user-visible changes in `CHANGELOG.md` under the affected version. Use `Added`, `Changed`, and `Fixed` sections. The date should be the release date (when the version is published), not the commit date.
-
-```markdown
-## [1.3.0] - YYYY-MM-DD
-
-### omni-analytics
-
-**Added**
-- Description of new capability
-
-**Changed**
-- Description of behavior change
-
-**Fixed**
-- Description of bug fix
-```
-
-**PR workflow:**
-
-Version bumps and `CHANGELOG.md` entries should be included in the same PR as the changes — not batched separately after the fact. If a PR introduces multiple changes across a release cycle without bumping, the changelog will drift and users reporting stale plugin versions will be harder to diagnose.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contributor guidance, including skill and agent authoring, validation, evals, versioning, changelog entries, and PR expectations.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with repo-specific contribution guidance for skills, agents, rules, validation, and PR scope
- replace the one-line contributing stub in `README.md` with a pointer to the new guide
- keep the content Omni-specific while following the general structure requested for the guide

## Why
The repo had only a minimal contributing note in the README. That was not enough to guide contributors on where changes belong, how to structure new skills or agents, or what to validate before opening a PR.

## Impact
Contributors now have a clear, centralized guide for working in this repository, which should make docs and workflow changes more consistent and easier to review.

## Validation
- ran `git diff --check -- CONTRIBUTING.md README.md`
- reviewed the rendered Markdown content locally

Closes #9