### PR TITLE
Replace curl commands with Omni CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,16 @@ npx skills update
 
 ## Setup
 
-Configure the Omni CLI:
+### Install the Omni CLI
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+```
+
+This downloads the latest release, verifies the SHA-256 checksum, and installs the `omni` binary to `/usr/local/bin` (or `~/.local/bin` if not writable). Pre-built binaries for all platforms are also available on the [GitHub Releases page](https://github.com/exploreomni/cli/releases).
+
+### Configure authentication
 
 ```bash
 # Option 1: Interactive profile setup (recommended)

--- a/README.md
+++ b/README.md
@@ -131,18 +131,20 @@ npx skills update
 
 ## Setup
 
-Set these environment variables before using the skills:
+Configure the Omni CLI:
 
 ```bash
+# Option 1: Interactive profile setup (recommended)
+omni config init
+
+# Option 2: Environment variables
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_KEY="your-api-key"
+export OMNI_API_TOKEN="your-api-key"
 ```
 
 API keys are created in **Settings > API Keys** (Organization Admin) or **User Profile > Manage Account > Generate Token** (Personal Access Token).
 
 **Admin note**: Some workflows, especially schema refresh, permissions, schedules, and other admin operations, require an Organization API Key.
-
-> **Token security**: These tokens can appear in terminal scrollback when used in shell commands. For team deployments, prefer a secrets manager or an MCP server wrapper where possible.
 
 ## What You Get
 

--- a/agents/omni-admin-agent.md
+++ b/agents/omni-admin-agent.md
@@ -49,6 +49,7 @@ You are an Omni Analytics instance administrator. Your job is to manage users, g
 
 ## Conventions
 
+- Run `omni agent-help` for a quick reference of all CLI commands and common workflows
 - Reference `omni-api-conventions` rule for auth and error handling
 - Always show current state before making changes
 - Use `omni-content-explorer` to find document IDs before setting permissions

--- a/agents/omni-admin-agent.md
+++ b/agents/omni-admin-agent.md
@@ -5,7 +5,7 @@ description: Omni Analytics instance administrator — manages users, groups, pe
 
 # Omni Admin
 
-You are an Omni Analytics instance administrator. Your job is to manage users, groups, permissions, schedules, connections, and access controls through the REST API.
+You are an Omni Analytics instance administrator. Your job is to manage users, groups, permissions, schedules, connections, and access controls through the Omni CLI.
 
 ## Workflow
 
@@ -32,20 +32,20 @@ You are an Omni Analytics instance administrator. Your job is to manage users, g
 ## Key API Patterns
 
 ### SCIM 2.0 (Users & Groups)
-- Endpoint prefix: `/api/scim/v2/`
-- Filter syntax: `?filter=userName eq "email@domain.com"` (URL-encode the filter)
-- PATCH operations use the SCIM `Operations` array format
+- Commands: `omni scim users-list`, `omni scim users-create`, `omni scim users-update`, `omni scim groups-list`, etc.
+- Filter syntax: `--filter 'userName eq "email@domain.com"'`
+- PATCH operations use the SCIM `Operations` array format via `--body`
 - User attributes use the custom schema `urn:omni:params:1.0:UserAttribute`
 
 ### Permissions
-- Document: `PUT /api/v1/documents/{id}/permissions`
-- Folder: `PUT /api/v1/folders/{id}/permissions`
+- Document: `omni documents update-permission-settings <identifier> --body '{...}'`
+- Folder: `omni folders add-permissions <folderId> --body '{...}'`
 - Both take a `permissions` array with `type` (user/group), `id`, and `access` (view/edit)
 
 ### Schedules
-- Create: `POST /api/v1/schedules`
+- Create: `omni schedules create --body '{...}'`
 - Requires `documentId`, `frequency`, and timezone
-- Recipients managed separately: `POST /api/v1/schedules/{id}/recipients`
+- Recipients managed separately: `omni schedules add-recipients <scheduleId> --body '{...}'`
 
 ## Conventions
 

--- a/agents/omni-analyst.md
+++ b/agents/omni-analyst.md
@@ -18,7 +18,7 @@ You are a principal data analyst working with Omni Analytics. Your job is to exp
    - What filters narrow the result set
    - What sort order makes the answer clearest
 
-3. **Query**: Use the `omni-query` skill to run queries via the REST API. Start broad, then narrow:
+3. **Query**: Use the `omni-query` skill to run queries via the Omni CLI. Start broad, then narrow:
    - First query: understand the shape and range of data
    - Follow-up queries: drill into segments, compare periods, find outliers
 
@@ -32,8 +32,7 @@ You are a principal data analyst working with Omni Analytics. Your job is to exp
 
 ## Conventions
 
-- Always use `$OMNI_BASE_URL` and `$OMNI_API_KEY` environment variables
-- Include `-L` in all curl commands (Omni uses redirects)
+- Configure the Omni CLI via `omni config init` or set `OMNI_BASE_URL` and `OMNI_API_TOKEN` environment variables
 - Use `resultType: "csv"` for easier result parsing in the terminal
 - When asked about trends, default to weekly granularity and sort ascending
 - When asked about "top N", sort descending by the relevant measure and limit appropriately

--- a/agents/omni-analyst.md
+++ b/agents/omni-analyst.md
@@ -32,6 +32,7 @@ You are a principal data analyst working with Omni Analytics. Your job is to exp
 
 ## Conventions
 
+- Run `omni agent-help` for a quick reference of all CLI commands and common workflows
 - Configure the Omni CLI via `omni config init` or set `OMNI_BASE_URL` and `OMNI_API_TOKEN` environment variables
 - Use `resultType: "csv"` for easier result parsing in the terminal
 - When asked about trends, default to weekly granularity and sort ascending

--- a/agents/omni-modeler.md
+++ b/agents/omni-modeler.md
@@ -30,7 +30,7 @@ You are a senior analytics engineer building Omni's semantic model. Your job is 
 
 4. **Validate**: After every write, run validation:
    ```
-   GET /api/v1/models/{modelId}/validate?branchId={branchId}
+   omni models validate <modelId> --branch-id <branchId>
    ```
    Fix any errors before proceeding.
 

--- a/agents/omni-modeler.md
+++ b/agents/omni-modeler.md
@@ -58,6 +58,7 @@ When building or updating topics, always consider Blobby:
 
 ## Conventions
 
+- Run `omni agent-help` for a quick reference of all CLI commands and common workflows
 - Reference `omni-yaml-conventions` rule for YAML syntax patterns
 - Reference `omni-api-conventions` rule for auth and error handling
 - Prefer `mode: "extension"` (shared model layer) over `combined`

--- a/rules/omni-api-conventions.mdc
+++ b/rules/omni-api-conventions.mdc
@@ -1,44 +1,64 @@
 ---
-description: Omni Analytics REST API conventions — authentication, base URL, error handling, and rate limits. Apply when making any curl or HTTP request to an Omni instance.
+description: Omni CLI conventions — authentication, command patterns, output handling, and error codes. Apply when making any Omni API call via the CLI.
 globs: []
 alwaysApply: false
 ---
 
-# Omni API Conventions
+# Omni CLI Conventions
 
 ## Authentication
 
-Every Omni API request requires a Bearer token in the `Authorization` header:
+The Omni CLI resolves credentials in this order (highest wins):
 
-```
-Authorization: Bearer $OMNI_API_KEY
-```
+1. `--token` flag on the command
+2. `OMNI_API_TOKEN` environment variable
+3. Profile's `apiKey` from config file (set via `omni config init`)
 
-Two key types exist:
+Two API key types exist:
 
 - **Organization API Key** — created in Settings > API Keys by an org admin. Required for SCIM user management, connection management, and most admin endpoints.
 - **Personal Access Token** — created in User Profile > Manage Account > Generate Token. Scoped to the user's permissions. Sufficient for querying, model exploration, and content browsing.
 
-Always use `$OMNI_BASE_URL` and `$OMNI_API_KEY` environment variables rather than hardcoded values.
+### Setup
 
-## Base URL Pattern
+```bash
+# Option 1: Interactive profile setup (recommended, one-time)
+omni config init
 
-All API endpoints follow:
+# Option 2: Environment variables
+export OMNI_BASE_URL="https://yourorg.omniapp.co"
+export OMNI_API_TOKEN="your-api-key"
+```
+
+Base URL is resolved in this order: `--base-url` flag > `OMNI_BASE_URL` env var > profile's `apiEndpoint`.
+
+## Command Pattern
+
+All CLI commands follow:
 
 ```
-$OMNI_BASE_URL/api/{version}/{resource}
+omni <group> <operation> [positional-args] [--flags] [--body 'JSON']
 ```
 
-- Stable endpoints: `/api/v1/...`
-- Beta endpoints: `/api/unstable/...` — subject to change but functional
-- SCIM endpoints: `/api/scim/v2/...` — standard SCIM 2.0 protocol
+- **Group**: the API resource (e.g., `models`, `documents`, `scim`, `query`)
+- **Operation**: the action (e.g., `list`, `create`, `yaml-get`)
+- **Positional args**: path parameters like `<modelId>`, `<identifier>`
+- **Flags**: query parameters as `--flag-name value`
+- **Body**: request body as `--body '{"key": "value"}'` or `--body -` to read from stdin
 
-## Request Conventions
+### Discovering Commands
 
-- Always include `-L` in curl commands (Omni issues redirects)
-- POST/PUT/PATCH requests need `Content-Type: application/json`
-- Query parameters use camelCase (e.g., `sortField`, `modelId`)
-- Request body fields also use camelCase
+```bash
+omni --help                        # List all command groups
+omni <group> --help                # List operations in a group
+omni <group> <operation> --help    # Show flags and positional args
+```
+
+## Output
+
+- All responses are JSON to stdout (pretty-printed by default)
+- Use `--compact` for single-line JSON (good for piping to `jq`)
+- Errors go to stderr as JSON with `error` and `status` fields
 
 ## Error Handling
 
@@ -46,7 +66,7 @@ Omni returns standard HTTP status codes:
 
 | Code | Meaning | Action |
 |------|---------|--------|
-| 401 | Invalid or expired API key | Check `$OMNI_API_KEY` |
+| 401 | Invalid or expired API key | Check your token / `omni config show` |
 | 403 | Insufficient permissions | Need higher role or org-level key |
 | 404 | Resource not found | Verify ID/identifier |
 | 422 | Validation error | Check request body |
@@ -72,4 +92,4 @@ List endpoints return cursor-based pagination:
 }
 ```
 
-Pass `?cursor={nextCursor}` to fetch subsequent pages.
+Pass `--cursor <nextCursor>` to fetch subsequent pages.

--- a/rules/omni-api-conventions.mdc
+++ b/rules/omni-api-conventions.mdc
@@ -60,6 +60,7 @@ omni <group> <operation> [positional-args] [--flags] [--body 'JSON']
 ### Discovering Commands
 
 ```bash
+omni agent-help                    # Agent-oriented guide with common workflows
 omni --help                        # List all command groups
 omni <group> --help                # List operations in a group
 omni <group> <operation> --help    # Show flags and positional args

--- a/rules/omni-api-conventions.mdc
+++ b/rules/omni-api-conventions.mdc
@@ -6,6 +6,17 @@ alwaysApply: false
 
 # Omni CLI Conventions
 
+## Installation
+
+If the `omni` command is not available, install it:
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+```
+
+Pre-built binaries for macOS (amd64/arm64), Linux (amd64/arm64), and Windows (amd64) are available on the [GitHub Releases page](https://github.com/exploreomni/cli/releases).
+
 ## Authentication
 
 The Omni CLI resolves credentials in this order (highest wins):

--- a/rules/omni-terminology.mdc
+++ b/rules/omni-terminology.mdc
@@ -42,8 +42,9 @@ The `mode` parameter in the YAML API controls which layer you write to:
 - Date timeframes use brackets: `orders.created_at[month]`
 - Available timeframes: `[date]`, `[week]`, `[month]`, `[quarter]`, `[year]`
 
-## Key URL Patterns
+## Key References
 
 - Base URL: `$OMNI_BASE_URL` (e.g., `https://yourorg.omniapp.co`)
+- CLI: `omni` command — auto-generated from the OpenAPI spec, handles auth and base URL via configuration
 - API docs: `https://docs.omni.co/api.md`
 - Modeling docs: `https://docs.omni.co/modeling.md`

--- a/rules/omni-yaml-conventions.mdc
+++ b/rules/omni-yaml-conventions.mdc
@@ -96,21 +96,21 @@ Getting `relationship_type` right prevents fanout and symmetric aggregate errors
 
 ## YAML API Write Pattern
 
-Always write via the API with a branch:
+Always write via the CLI with a branch:
 
-```json
-{
+```bash
+omni models yaml-create <modelId> --body '{
   "fileName": "my_view.view",
   "yaml": "...",
   "mode": "extension",
   "branchId": "{branchId}",
   "commitMessage": "Descriptive message"
-}
+}'
 ```
 
 - `mode: "extension"` writes to the shared model layer (most common)
 - To delete a file, send empty `yaml` with `mode: "extension"`
-- Always validate after writing: `GET /api/v1/models/{modelId}/validate?branchId={branchId}`
+- Always validate after writing: `omni models validate <modelId> --branch-id <branchId>`
 
 ## Common Pitfalls
 

--- a/skills/omni-admin/SKILL.md
+++ b/skills/omni-admin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omni-admin
-description: Administer an Omni Analytics instance — manage connections, users, groups, user attributes, permissions, schedules, and schema refreshes via the REST API. Use this skill whenever someone wants to manage users or groups, set up permissions on a dashboard or folder, configure user attributes, create or modify schedules, manage database connections, refresh a schema, set up access controls, provision users, or any variant of "add a user", "give access to", "set up permissions", "who has access", "configure connection", "refresh the schema", or "schedule a delivery".
+description: Administer an Omni Analytics instance — manage connections, users, groups, user attributes, permissions, schedules, and schema refreshes via the Omni CLI. Use this skill whenever someone wants to manage users or groups, set up permissions on a dashboard or folder, configure user attributes, create or modify schedules, manage database connections, refresh a schema, set up access controls, provision users, or any variant of "add a user", "give access to", "set up permissions", "who has access", "configure connection", "refresh the schema", or "schedule a delivery".
 ---
 
 # Omni Admin
@@ -12,122 +12,100 @@ Manage your Omni instance — connections, users, groups, user attributes, permi
 ## Prerequisites
 
 ```bash
+# Option 1: Interactive profile setup (recommended)
+omni config init
+
+# Option 2: Environment variables
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_KEY="your-api-key"
+export OMNI_API_TOKEN="your-api-key"
 ```
 
-## API Discovery
-
-When unsure whether an endpoint or parameter exists, fetch the OpenAPI spec:
+## Discovering Commands
 
 ```bash
-curl -L "$OMNI_BASE_URL/openapi.json" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni scim --help             # User and group management
+omni schedules --help        # Schedule operations
+omni connections --help      # Connection management
+omni documents --help        # Document permissions
+omni folders --help          # Folder permissions
 ```
-
-Use this to verify endpoints, available parameters, and request/response schemas before making calls.
 
 ## Connections
 
 ```bash
 # List connections
-curl -L "$OMNI_BASE_URL/api/v1/connections" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni connections list
 
 # Schema refresh schedules
-curl -L "$OMNI_BASE_URL/api/v1/connections/{connectionId}/schedules" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni connections schedules-list <connectionId>
 
 # Connection environments
-curl -L "$OMNI_BASE_URL/api/v1/connection-environments" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni connections connection-environments-list
 ```
 
 ## User Management (SCIM 2.0)
 
-Endpoint prefix: `/api/scim/v2/`
-
 ```bash
 # List users
-curl -L "$OMNI_BASE_URL/api/scim/v2/users" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni scim users-list
 
-# Find by email (URL-encode the filter)
-curl -L "$OMNI_BASE_URL/api/scim/v2/users?filter=userName%20eq%20%22user@company.com%22" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+# Find by email
+omni scim users-list --filter 'userName eq "user@company.com"'
 
 # Create user
-curl -L -X POST "$OMNI_BASE_URL/api/scim/v2/users" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
-    "userName": "newuser@company.com",
-    "displayName": "New User",
-    "active": true,
-    "emails": [{ "primary": true, "value": "newuser@company.com" }]
-  }'
+omni scim users-create --body '{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "userName": "newuser@company.com",
+  "displayName": "New User",
+  "active": true,
+  "emails": [{ "primary": true, "value": "newuser@company.com" }]
+}'
 
 # Deactivate user
-curl -L -X PATCH "$OMNI_BASE_URL/api/scim/v2/users/{userId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
-    "Operations": [{ "op": "replace", "path": "active", "value": false }]
-  }'
+omni scim users-update <userId> --body '{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "Operations": [{ "op": "replace", "path": "active", "value": false }]
+}'
 
 # Delete user
-curl -L -X DELETE "$OMNI_BASE_URL/api/scim/v2/users/{userId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni scim users-delete <userId>
 ```
 
 ## Group Management (SCIM 2.0)
 
 ```bash
 # List groups
-curl -L "$OMNI_BASE_URL/api/scim/v2/groups" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni scim groups-list
 
 # Create group
-curl -L -X POST "$OMNI_BASE_URL/api/scim/v2/groups" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-    "displayName": "Analytics Team",
-    "members": [{ "value": "user-uuid-1" }]
-  }'
+omni scim groups-create --body '{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+  "displayName": "Analytics Team",
+  "members": [{ "value": "user-uuid-1" }]
+}'
 
 # Add members
-curl -L -X PATCH "$OMNI_BASE_URL/api/scim/v2/groups/{groupId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-    "Operations": [{ "op": "add", "path": "members", "value": [{ "value": "new-user-uuid" }] }]
-  }'
+omni scim groups-update <groupId> --body '{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+  "Operations": [{ "op": "add", "path": "members", "value": [{ "value": "new-user-uuid" }] }]
+}'
 ```
 
 ## User Attributes
 
 ```bash
 # List attributes
-curl -L "$OMNI_BASE_URL/api/v1/user-attributes" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni user-attributes list
 
 # Set attribute on user (via SCIM)
-curl -L -X PATCH "$OMNI_BASE_URL/api/scim/v2/users/{userId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
-    "Operations": [{
-      "op": "replace",
-      "path": "urn:omni:params:1.0:UserAttribute:region",
-      "value": "West Coast"
-    }]
-  }'
+omni scim users-update <userId> --body '{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "Operations": [{
+    "op": "replace",
+    "path": "urn:omni:params:1.0:UserAttribute:region",
+    "value": "West Coast"
+  }]
+}'
 ```
 
 User attributes work with `access_filters` in topics for row-level security.
@@ -136,112 +114,82 @@ User attributes work with `access_filters` in topics for row-level security.
 
 ```bash
 # Get/set model roles for a user
-curl -L "$OMNI_BASE_URL/api/v1/users/{userId}/model-roles" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni users get-model-roles <userId>
 
-curl -L -X POST "$OMNI_BASE_URL/api/v1/users/{userId}/model-roles" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "modelId": "{modelId}", "role": "VIEWER" }'
+omni users assign-model-role <userId> --body '{ "modelId": "{modelId}", "role": "VIEWER" }'
 
 # Get/set model roles for a group
-curl -L "$OMNI_BASE_URL/api/v1/user-groups/{groupId}/model-roles" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni users user-groups-get-model-roles <groupId>
 
-curl -L -X POST "$OMNI_BASE_URL/api/v1/user-groups/{groupId}/model-roles" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "modelId": "{modelId}", "role": "VIEWER" }'
+omni users user-groups-assign-model-role <groupId> --body '{ "modelId": "{modelId}", "role": "VIEWER" }'
 ```
 
 ## Document Permissions
 
 ```bash
 # Get permissions for a user (userId required)
-curl -L "$OMNI_BASE_URL/api/v1/documents/{documentId}/permissions?userId={userId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents get-permissions <documentId> --user-id <userId>
 
 # Set permissions
-curl -L -X PUT "$OMNI_BASE_URL/api/v1/documents/{documentId}/permissions" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "permissions": [
-      { "type": "group", "id": "group-uuid", "access": "view" },
-      { "type": "user", "id": "user-uuid", "access": "edit" }
-    ]
-  }'
+omni documents update-permission-settings <documentId> --body '{
+  "permissions": [
+    { "type": "group", "id": "group-uuid", "access": "view" },
+    { "type": "user", "id": "user-uuid", "access": "edit" }
+  ]
+}'
 ```
 
 ## Folder Permissions
 
 ```bash
 # Get
-curl -L "$OMNI_BASE_URL/api/v1/folders/{folderId}/permissions" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni folders get-permissions <folderId>
 
 # Set
-curl -L -X PUT "$OMNI_BASE_URL/api/v1/folders/{folderId}/permissions" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "permissions": [{ "type": "group", "id": "group-uuid", "access": "view" }]
-  }'
+omni folders add-permissions <folderId> --body '{
+  "permissions": [{ "type": "group", "id": "group-uuid", "access": "view" }]
+}'
 ```
 
 ## Schedules
 
 ```bash
 # List schedules
-curl -L "$OMNI_BASE_URL/api/v1/schedules" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni schedules list
 
 # Create schedule
-curl -L -X POST "$OMNI_BASE_URL/api/v1/schedules" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "documentId": "dashboard-identifier",
-    "frequency": "weekly",
-    "dayOfWeek": "monday",
-    "hour": 9,
-    "timezone": "America/Los_Angeles",
-    "format": "pdf"
-  }'
+omni schedules create --body '{
+  "documentId": "dashboard-identifier",
+  "frequency": "weekly",
+  "dayOfWeek": "monday",
+  "hour": 9,
+  "timezone": "America/Los_Angeles",
+  "format": "pdf"
+}'
 
 # Manage recipients
-curl -L "$OMNI_BASE_URL/api/v1/schedules/{scheduleId}/recipients" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni schedules recipients-get <scheduleId>
 
-curl -L -X POST "$OMNI_BASE_URL/api/v1/schedules/{scheduleId}/recipients" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "recipients": [{ "type": "email", "value": "team@company.com" }] }'
+omni schedules add-recipients <scheduleId> --body '{ "recipients": [{ "type": "email", "value": "team@company.com" }] }'
 ```
 
 ## Cache and Validation
 
 ```bash
 # Reset cache policy
-curl -L -X POST "$OMNI_BASE_URL/api/v1/models/{modelId}/cache_reset/{policyName}" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "resetAt": "2025-01-30T22:30:52.872Z" }'
+omni models cache-reset <modelId> <policyName> --body '{ "resetAt": "2025-01-30T22:30:52.872Z" }'
 
 # Content validator (find broken field references across all dashboards and tiles)
 # Useful for blast-radius analysis: remove a field on a branch, then run the
 # validator against that branch to see what content would break.
 # See the Field Impact Analysis section in omni-model-explorer for the full workflow.
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/content-validator" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models content-validator-get <modelId>
 
 # Run against a specific branch (e.g., after removing a field)
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/content-validator?branchId={branchId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models content-validator-get <modelId> --branch-id <branchId>
 
 # Git configuration
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/git" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models git-get <modelId>
 ```
 
 ## Docs Reference

--- a/skills/omni-admin/SKILL.md
+++ b/skills/omni-admin/SKILL.md
@@ -12,14 +12,8 @@ Manage your Omni instance — connections, users, groups, user attributes, permi
 ## Prerequisites
 
 ```bash
-# Install the CLI (macOS / Linux)
-curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
-
-# Configure authentication
-omni config init
+command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 ```
-
-Or set environment variables instead of using `omni config init`:
 
 ```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"

--- a/skills/omni-admin/SKILL.md
+++ b/skills/omni-admin/SKILL.md
@@ -12,10 +12,16 @@ Manage your Omni instance — connections, users, groups, user attributes, permi
 ## Prerequisites
 
 ```bash
-# Option 1: Interactive profile setup (recommended)
-omni config init
+# Install the CLI (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 
-# Option 2: Environment variables
+# Configure authentication
+omni config init
+```
+
+Or set environment variables instead of using `omni config init`:
+
+```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
 export OMNI_API_TOKEN="your-api-key"
 ```

--- a/skills/omni-ai-optimizer/SKILL.md
+++ b/skills/omni-ai-optimizer/SKILL.md
@@ -12,14 +12,8 @@ Optimize your Omni semantic model so Blobby (Omni's AI assistant) returns accura
 ## Prerequisites
 
 ```bash
-# Install the CLI (macOS / Linux)
-curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
-
-# Configure authentication
-omni config init
+command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 ```
-
-Or set environment variables instead of using `omni config init`:
 
 ```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"

--- a/skills/omni-ai-optimizer/SKILL.md
+++ b/skills/omni-ai-optimizer/SKILL.md
@@ -12,10 +12,16 @@ Optimize your Omni semantic model so Blobby (Omni's AI assistant) returns accura
 ## Prerequisites
 
 ```bash
-# Option 1: Interactive profile setup (recommended)
-omni config init
+# Install the CLI (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 
-# Option 2: Environment variables
+# Configure authentication
+omni config init
+```
+
+Or set environment variables instead of using `omni config init`:
+
+```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
 export OMNI_API_TOKEN="your-api-key"
 ```

--- a/skills/omni-ai-optimizer/SKILL.md
+++ b/skills/omni-ai-optimizer/SKILL.md
@@ -12,22 +12,22 @@ Optimize your Omni semantic model so Blobby (Omni's AI assistant) returns accura
 ## Prerequisites
 
 ```bash
+# Option 1: Interactive profile setup (recommended)
+omni config init
+
+# Option 2: Environment variables
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_KEY="your-api-key"
+export OMNI_API_TOKEN="your-api-key"
 ```
 
 Requires **Modeler** or **Connection Admin** permissions.
 
-## API Discovery
-
-When unsure whether an endpoint or parameter exists, fetch the OpenAPI spec:
+## Discovering Commands
 
 ```bash
-curl -L "$OMNI_BASE_URL/openapi.json" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models --help                    # List all model operations
+omni models yaml-create --help        # Show flags for writing YAML
 ```
-
-Use this to verify endpoints, available parameters, and request/response schemas before making calls.
 
 ## How Blobby Works
 
@@ -48,15 +48,12 @@ Impact order: ai_context > ai_fields > sample_queries > synonyms > field descrip
 Add via the YAML API:
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/models/{modelId}/yaml" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "fileName": "order_transactions.topic",
-    "yaml": "base_view: order_items\nlabel: Order Transactions\nai_context: |\n  Map \"revenue\" → total_revenue. Map \"orders\" → count.\n  Map \"customers\" → unique_users.\n  Status values: complete, pending, cancelled, returned.\n  Only complete orders for revenue unless specified otherwise.",
-    "mode": "extension",
-    "commitMessage": "Add AI context to order transactions topic"
-  }'
+omni models yaml-create <modelId> --body '{
+  "fileName": "order_transactions.topic",
+  "yaml": "base_view: order_items\nlabel: Order Transactions\nai_context: |\n  Map \"revenue\" → total_revenue. Map \"orders\" → count.\n  Map \"customers\" → unique_users.\n  Status values: complete, pending, cancelled, returned.\n  Only complete orders for revenue unless specified otherwise.",
+  "mode": "extension",
+  "commitMessage": "Add AI context to order transactions topic"
+}'
 ```
 
 ### What Makes Good ai_context

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -21,14 +21,8 @@ Create, update, and manage Omni documents and dashboards programmatically via th
 ## Prerequisites
 
 ```bash
-# Install the CLI (macOS / Linux)
-curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
-
-# Configure authentication
-omni config init
+command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 ```
-
-Or set environment variables instead of using `omni config init`:
 
 ```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: omni-content-builder
-description: Create, update, and manage Omni Analytics documents and dashboards programmatically — document lifecycle, tiles, visualizations, filters, and layouts — using the REST API. Use this skill whenever someone wants to build a dashboard, create a workbook, add tiles or charts, configure dashboard filters, update an existing dashboard's model, set up a KPI view, create visualizations, lay out a dashboard, create a document, rename a workbook, delete a dashboard, move a document to a folder, duplicate a dashboard, or any variant of "build a dashboard for", "create a report showing", "add a chart to", "make a dashboard", "update the dashboard layout", "rename this document", "move to folder", or "delete this dashboard". Also use when modifying dashboard-level model customizations like workbook-specific joins or fields.
+description: Create, update, and manage Omni Analytics documents and dashboards programmatically — document lifecycle, tiles, visualizations, filters, and layouts — using the Omni CLI. Use this skill whenever someone wants to build a dashboard, create a workbook, add tiles or charts, configure dashboard filters, update an existing dashboard's model, set up a KPI view, create visualizations, lay out a dashboard, create a document, rename a workbook, delete a dashboard, move a document to a folder, duplicate a dashboard, or any variant of "build a dashboard for", "create a report showing", "add a chart to", "make a dashboard", "update the dashboard layout", "rename this document", "move to folder", or "delete this dashboard". Also use when modifying dashboard-level model customizations like workbook-specific joins or fields.
 ---
 
 # Omni Content Builder
 
-Create, update, and manage Omni documents and dashboards programmatically via the REST API — document lifecycle, workbook models, filters, and dashboard content.
+Create, update, and manage Omni documents and dashboards programmatically via the Omni CLI — document lifecycle, workbook models, filters, and dashboard content.
 
 > **Tip**: Use `omni-model-explorer` to understand available fields and `omni-content-explorer` to find existing dashboards to modify or learn from.
 
 ## Known Issues & Safe Defaults
 
-- **Always test queries before creating a dashboard** — run each planned query via `POST /api/v1/query/run` first, including the filters you intend to use. This catches bad field names, missing joins, and malformed filter expressions before they become broken tiles.
+- **Always test queries before creating a dashboard** — run each planned query via `omni query run` first, including the filters you intend to use. This catches bad field names, missing joins, and malformed filter expressions before they become broken tiles.
 - **Chart rendering**: Complex chart types may show "No chart available" in the Omni UI if `config`, `visType`, or `prefersChart` are misconfigured. Default to `chartType: "table"` for reliable rendering, and configure chart visualizations in the Omni UI.
 - **Every query must include at least one measure** — a query with only dimensions produces empty/nonsense tiles (e.g., just months with no data).
 - **Use `identifier` not `id`** for all document API calls — `.id` is null for workbook-type documents and will silently fail.
@@ -21,20 +21,21 @@ Create, update, and manage Omni documents and dashboards programmatically via th
 ## Prerequisites
 
 ```bash
+# Option 1: Interactive profile setup (recommended)
+omni config init
+
+# Option 2: Environment variables
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_KEY="your-api-key"
+export OMNI_API_TOKEN="your-api-key"
 ```
 
-## API Discovery
-
-When unsure whether an endpoint or parameter exists, fetch the OpenAPI spec:
+## Discovering Commands
 
 ```bash
-curl -L "$OMNI_BASE_URL/openapi.json" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents --help           # Document operations
+omni dashboards --help          # Dashboard operations
+omni models yaml-create --help  # Writing model YAML
 ```
-
-Use this to verify endpoints, available parameters, and request/response schemas before making calls.
 
 ## Dashboard Architecture
 
@@ -50,13 +51,10 @@ Documents can be created with full query and visualization configurations via `q
 ### Create Document (Name Only)
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/documents" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "modelId": "your-model-id",
-    "name": "Q1 Revenue Report"
-  }'
+omni documents create --body '{
+  "modelId": "your-model-id",
+  "name": "Q1 Revenue Report"
+}'
 ```
 
 Returns the new document's `identifier`, `workbookId`, and `dashboardId`.
@@ -68,32 +66,29 @@ Use `queryPresentations` to create a document pre-populated with query tabs and 
 > **Doc gap**: The [create-document API docs](https://docs.omni.co/api/documents/create-document.md) mention queryPresentations but don't show the complete structure. This section documents the full format.
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/documents" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "modelId": "your-model-id",
-    "name": "Q1 Revenue Report",
-    "queryPresentations": [
-      {
-        "name": "Monthly Revenue Trend",
-        "topicName": "order_items",
-        "prefersChart": true,
-        "visType": "basic",
+omni documents create --body '{
+  "modelId": "your-model-id",
+  "name": "Q1 Revenue Report",
+  "queryPresentations": [
+    {
+      "name": "Monthly Revenue Trend",
+      "topicName": "order_items",
+      "prefersChart": true,
+      "visType": "basic",
+      "fields": ["order_items.created_at[month]", "order_items.total_revenue"],
+      "query": {
+        "table": "order_items",
         "fields": ["order_items.created_at[month]", "order_items.total_revenue"],
-        "query": {
-          "table": "order_items",
-          "fields": ["order_items.created_at[month]", "order_items.total_revenue"],
-          "sorts": [{ "column_name": "order_items.created_at[month]", "sort_descending": false }],
-          "filters": { "order_items.created_at": "this quarter" },
-          "limit": 100,
-          "join_paths_from_topic_name": "order_items",
-          "visConfig": { "chartType": "lineColor" }
-        },
-        "config": {}
-      }
-    ]
-  }'
+        "sorts": [{ "column_name": "order_items.created_at[month]", "sort_descending": false }],
+        "filters": { "order_items.created_at": "this quarter" },
+        "limit": 100,
+        "join_paths_from_topic_name": "order_items",
+        "visConfig": { "chartType": "lineColor" }
+      },
+      "config": {}
+    }
+  ]
+}'
 ```
 
 > **Tip**: Default to `"config": {}` for reliable rendering — Omni will auto-generate chart config. For precise chart styling, build a reference dashboard in the UI and read it back via `GET /api/v1/documents/{documentId}`. See [references/queryPresentations.md](references/queryPresentations.md) for complete config examples by chart type (KPI, line, bar, area, pie, scatter, etc.).
@@ -170,39 +165,34 @@ The most reliable way to learn `config`, `visType`, and field names is to read a
 **Step 1: Find a reference dashboard**
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/documents" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents list
 ```
 
 **Step 2: Get its full document**
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/documents/{documentId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents get <documentId>
 ```
 
 Returns the complete `queryPresentations` array including `topicName`, `visConfig`, `config`, and the full `query` object for each tile — use this as the source of truth when recreating or templating dashboards.
 
-> **Tip**: Build a reference dashboard in the Omni UI with the chart types and styling you want, then read it via `GET /api/v1/documents/{documentId}` to capture the exact `queryPresentations` structure to use as a template.
+> **Tip**: Build a reference dashboard in the Omni UI with the chart types and styling you want, then read it via `omni documents get <documentId>` to capture the exact `queryPresentations` structure to use as a template.
 
 #### Caveats When Reusing queryPresentations
 
 These apply when copying queryPresentations from an existing document (for both creating new dashboards and updating existing ones):
 
 - **Strip `model_extension_id`** from each query object — these reference model extensions scoped to the source document and will cause "Chart unavailable" errors.
-- **Filter to the tiles you want** — `GET /api/v1/documents/{id}` returns all queries including workbook-only tabs not shown on the dashboard. Only include the `queryPresentations` you want as visible tiles.
+- **Filter to the tiles you want** — `omni documents get` returns all queries including workbook-only tabs not shown on the dashboard. Only include the `queryPresentations` you want as visible tiles.
 - **Queries without `topicName` are valid** — SQL-mode and tab-selector queries won't have a `topicName`. Do not add one.
 
 ### Rename Document
 
 ```bash
-curl -L -X PATCH "$OMNI_BASE_URL/api/v1/documents/{documentId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "Q1 Revenue Report (Updated)",
-    "clearExistingDraft": true
-  }'
+omni documents update <documentId> --body '{
+  "name": "Q1 Revenue Report (Updated)",
+  "clearExistingDraft": true
+}'
 ```
 
 Set `clearExistingDraft: true` if the document has an existing draft, otherwise the API returns 409 Conflict.
@@ -210,8 +200,7 @@ Set `clearExistingDraft: true` if the document has an existing draft, otherwise 
 ### Delete Document
 
 ```bash
-curl -L -X DELETE "$OMNI_BASE_URL/api/v1/documents/{documentId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents delete <documentId>
 ```
 
 Soft-deletes the document (moves to Trash).
@@ -219,13 +208,10 @@ Soft-deletes the document (moves to Trash).
 ### Move Document
 
 ```bash
-curl -L -X PUT "$OMNI_BASE_URL/api/v1/documents/{documentId}/move" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "folderPath": "/Marketing/Reports",
-    "scope": "organization"
-  }'
+omni documents move <documentId> --body '{
+  "folderPath": "/Marketing/Reports",
+  "scope": "organization"
+}'
 ```
 
 Use `"folderPath": null` to move to root. `scope` is optional — auto-computed from the destination folder.
@@ -233,13 +219,10 @@ Use `"folderPath": null` to move to root. `scope` is optional — auto-computed 
 ### Duplicate Document
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/documents/{documentId}/duplicate" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "Copy of Q1 Revenue Report",
-    "folderPath": "/Marketing/Reports"
-  }'
+omni documents duplicate <documentId> --body '{
+  "name": "Copy of Q1 Revenue Report",
+  "folderPath": "/Marketing/Reports"
+}'
 ```
 
 Only published documents can be duplicated. Draft documents return 404.
@@ -257,8 +240,7 @@ Update the tiles, queries, filters, and visualizations on an existing dashboard 
 **Step 1 — Read the existing document** to get its current state:
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/documents/{documentId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents get <documentId>
 ```
 
 This returns the full document including `queryPresentations`, `filterConfig`, `filterOrder`, `modelId`, `name`, and other fields. Use this as your starting point.
@@ -273,8 +255,10 @@ This returns the full document including `queryPresentations`, `filterConfig`, `
 **Step 3 — PUT the updated document:**
 
 ```bash
+# Note: Full document replacement via PUT is not yet available in the CLI.
+# Use direct HTTP for now, or use omni documents update for partial updates (PATCH).
 curl -L -X PUT "$OMNI_BASE_URL/api/v1/documents/{documentId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
+  -H "Authorization: Bearer $OMNI_API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "modelId": "your-model-id",
@@ -322,21 +306,17 @@ Push custom dimensions and measures to a specific dashboard by writing to its wo
 **Step 1 — get the document to find its `workbook_id`:**
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/documents/{documentId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents get <documentId>
 # → response includes "workbook_id"
 ```
 
 **Step 2 — POST YAML to the workbook model:**
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/unstable/models/{workbookId}/yaml" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "fileName": "order_items.view",
-    "yaml": "views:\n  order_items:\n    dimensions:\n      is_high_value:\n        sql: \"${sale_price} > 100\"\n        label: High Value Order\n    measures:\n      high_value_count:\n        sql: \"${order_items.id}\"\n        aggregate_type: count_distinct\n        label: High Value Orders"
-  }'
+omni models yaml-create <workbookId> --body '{
+  "fileName": "order_items.view",
+  "yaml": "views:\n  order_items:\n    dimensions:\n      is_high_value:\n        sql: \"${sale_price} > 100\"\n        label: High Value Order\n    measures:\n      high_value_count:\n        sql: \"${order_items.id}\"\n        aggregate_type: count_distinct\n        label: High Value Orders"
+}'
 ```
 
 `fileName` must be `"model"`, `"relationships"`, or end with `.view` or `.topic`. The `yaml` value is a YAML string (not a JSON object). Writing to a workbook model skips git sync entirely — authorization is still checked against the underlying shared model's permissions.
@@ -346,8 +326,7 @@ curl -L -X POST "$OMNI_BASE_URL/api/unstable/models/{workbookId}/yaml" \
 ### Get Current Filters
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/dashboards/{dashboardId}/filters" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni dashboards get-filters <dashboardId>
 ```
 
 ### Update Filters
@@ -355,41 +334,38 @@ curl -L "$OMNI_BASE_URL/api/v1/dashboards/{dashboardId}/filters" \
 Filters can be updated via two approaches:
 
 1. **`PUT /api/v1/documents/{documentId}`** (recommended) — update filters as part of a full document update. Include `filterConfig` and `filterOrder` alongside `queryPresentations` and other required fields. See the [Update Existing Dashboard](#update-existing-dashboard) section.
-2. **`PATCH /api/v1/dashboards/{id}/filters`** — partial filter update. Has been reported to return 405 or 500 in some configurations.
+2. **`omni dashboards update-filters <dashboardId>`** — partial filter update. Has been reported to return 405 or 500 in some configurations.
 
-For **new dashboards**, the most reliable way is to include `filterConfig` and `filterOrder` in the initial `POST /api/v1/documents` call. See [references/filterConfig.md](references/filterConfig.md) for complete examples of each filter type.
+For **new dashboards**, the most reliable way is to include `filterConfig` and `filterOrder` in the initial `omni documents create` call. See [references/filterConfig.md](references/filterConfig.md) for complete examples of each filter type.
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/documents" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "modelId": "your-model-id",
-    "name": "Filtered Dashboard",
-    "filterConfig": {
-      "date_filter": {
-        "type": "date",
-        "label": "Date Range",
-        "fieldName": "order_items.created_at",
-        "kind": "TIME_FOR_INTERVAL_DURATION",
-        "ui_type": "PAST",
-        "left_side": "6 months ago",
-        "right_side": "6 months"
-      },
-      "state_filter": {
-        "type": "string",
-        "label": "State",
-        "kind": "EQUALS",
-        "fieldName": "users.state",
-        "values": []
-      }
+omni documents create --body '{
+  "modelId": "your-model-id",
+  "name": "Filtered Dashboard",
+  "filterConfig": {
+    "date_filter": {
+      "type": "date",
+      "label": "Date Range",
+      "fieldName": "order_items.created_at",
+      "kind": "TIME_FOR_INTERVAL_DURATION",
+      "ui_type": "PAST",
+      "left_side": "6 months ago",
+      "right_side": "6 months"
     },
-    "filterOrder": ["date_filter", "state_filter"],
-    "queryPresentations": [...]
-  }'
+    "state_filter": {
+      "type": "string",
+      "label": "State",
+      "kind": "EQUALS",
+      "fieldName": "users.state",
+      "values": []
+    }
+  },
+  "filterOrder": ["date_filter", "state_filter"],
+  "queryPresentations": [...]
+}'
 ```
 
-The keys in `filterConfig` (e.g., `"date_filter"`) are arbitrary IDs — they must match the entries in `filterOrder`. To learn the exact filter structure, read filters from an existing dashboard with `GET /api/v1/dashboards/{dashboardId}/filters`.
+The keys in `filterConfig` (e.g., `"date_filter"`) are arbitrary IDs — they must match the entries in `filterOrder`. To learn the exact filter structure, read filters from an existing dashboard with `omni dashboards get-filters <dashboardId>`.
 
 ### Filter Types
 
@@ -431,15 +407,15 @@ The `identifier` comes from the document's `identifier` field in API responses (
 ### API-First (Full Programmatic Creation)
 
 1. **Discover fields** — use `omni-model-explorer` to find topic + fields
-2. **Test each query** — run every query you plan to include via `POST /api/v1/query/run` (using `omni-query`) before building the dashboard. Include the same filters you plan to use in `filterConfig` as query-level filters to confirm they parse correctly. This catches field name typos, missing join paths, bad filter expressions, and permission errors before they become broken tiles.
-3. **Create document** — single `POST /api/v1/documents` with `queryPresentations` + `filterConfig` + `filterOrder` all in one call
+2. **Test each query** — run every query you plan to include via `omni query run` (using `omni-query`) before building the dashboard. Include the same filters you plan to use in `filterConfig` as query-level filters to confirm they parse correctly. This catches field name typos, missing join paths, bad filter expressions, and permission errors before they become broken tiles.
+3. **Create document** — single `omni documents create` with `queryPresentations` + `filterConfig` + `filterOrder` all in one call
 4. **Share the link** — return `{OMNI_BASE_URL}/dashboards/{identifier}` to the user
 5. **Refine in UI** — tile layout, chart styling, and advanced config are best done in the Omni UI
 
 ### Update Existing Dashboard
 
-1. **Find the dashboard** — use `omni-content-explorer` or `GET /api/v1/documents` to locate it
-2. **Read its current state** — `GET /api/v1/documents/{documentId}` to get the full document including `queryPresentations`, `filterConfig`, etc.
+1. **Find the dashboard** — use `omni-content-explorer` or `omni documents list` to locate it
+2. **Read its current state** — `omni documents get <documentId>` to get the full document including `queryPresentations`, `filterConfig`, etc.
 3. **Modify** — add, remove, or edit entries in the `queryPresentations` array; update `filterConfig`/`filterOrder` as needed
 4. **PUT the update** — `PUT /api/v1/documents/{documentId}` with the complete modified document and `clearExistingDraft: true`
 5. **Share the link** — return `{OMNI_BASE_URL}/dashboards/{identifier}` to the user
@@ -454,14 +430,10 @@ The `identifier` comes from the document's `identifier` field in API responses (
 
 ```bash
 # Start async download
-curl -L -X POST "$OMNI_BASE_URL/api/v1/dashboards/{dashboardId}/download" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "format": "pdf" }'
+omni dashboards download <dashboardId> --body '{ "format": "pdf" }'
 
 # Poll job
-curl -L "$OMNI_BASE_URL/api/v1/dashboards/{dashboardId}/download/{jobId}/status" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni dashboards download-status <dashboardId> <jobId>
 ```
 
 ## Docs Reference

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -21,10 +21,16 @@ Create, update, and manage Omni documents and dashboards programmatically via th
 ## Prerequisites
 
 ```bash
-# Option 1: Interactive profile setup (recommended)
-omni config init
+# Install the CLI (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 
-# Option 2: Environment variables
+# Configure authentication
+omni config init
+```
+
+Or set environment variables instead of using `omni config init`:
+
+```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
 export OMNI_API_TOKEN="your-api-key"
 ```

--- a/skills/omni-content-explorer/SKILL.md
+++ b/skills/omni-content-explorer/SKILL.md
@@ -1,63 +1,58 @@
 ---
 name: omni-content-explorer
-description: Find, browse, and organize content in Omni Analytics — dashboards, workbooks, folders, and labels — using the REST API. Use this skill whenever someone wants to find an existing dashboard, search for content, list workbooks, browse folders, see what dashboards exist, find popular reports, download a dashboard as PDF or PNG, favorite content, manage labels on documents, or any variant of "find the dashboard about", "what reports do we have", "show me our dashboards", "where is the sales report", or "download this dashboard".
+description: Find, browse, and organize content in Omni Analytics — dashboards, workbooks, folders, and labels — using the Omni CLI. Use this skill whenever someone wants to find an existing dashboard, search for content, list workbooks, browse folders, see what dashboards exist, find popular reports, download a dashboard as PDF or PNG, favorite content, manage labels on documents, or any variant of "find the dashboard about", "what reports do we have", "show me our dashboards", "where is the sales report", or "download this dashboard".
 ---
 
 # Omni Content Explorer
 
-Find, browse, and organize Omni content — dashboards, workbooks, and folders — through the REST API.
+Find, browse, and organize Omni content — dashboards, workbooks, and folders — through the Omni CLI.
 
 ## Prerequisites
 
 ```bash
+# Option 1: Interactive profile setup (recommended)
+omni config init
+
+# Option 2: Environment variables
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_KEY="your-api-key"
+export OMNI_API_TOKEN="your-api-key"
 ```
 
-## API Discovery
-
-When unsure whether an endpoint or parameter exists, fetch the OpenAPI spec:
+## Discovering Commands
 
 ```bash
-curl -L "$OMNI_BASE_URL/openapi.json" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni content --help     # Content operations
+omni documents --help   # Document operations
+omni folders --help     # Folder operations
 ```
-
-Use this to verify endpoints, available parameters, and request/response schemas before making calls.
 
 ## Browsing Content
 
 ### List All Content
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/content" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni content list
 ```
 
 ### With Counts and Labels
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/content?include=_count,labels" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni content list --include '_count,labels'
 ```
 
 ### Filter and Sort
 
 ```bash
 # By label
-curl -L "$OMNI_BASE_URL/api/v1/content?labels=finance,marketing" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni content list --labels finance,marketing
 
 # By scope
-curl -L "$OMNI_BASE_URL/api/v1/content?scope=organization" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni content list --scope organization
 
 # Sort by popularity or recency
-curl -L "$OMNI_BASE_URL/api/v1/content?sortField=favorites" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni content list --sort-field favorites
 
-curl -L "$OMNI_BASE_URL/api/v1/content?sortField=updatedAt" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni content list --sort-field updatedAt
 ```
 
 ### Pagination
@@ -65,8 +60,7 @@ curl -L "$OMNI_BASE_URL/api/v1/content?sortField=updatedAt" \
 Responses include `pageInfo` with cursor-based pagination. Fetch next page:
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/content?cursor={nextCursor}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni content list --cursor <nextCursor>
 ```
 
 ## Working with Documents
@@ -74,12 +68,10 @@ curl -L "$OMNI_BASE_URL/api/v1/content?cursor={nextCursor}" \
 ### List Documents
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/documents" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents list
 
 # Filter by creator
-curl -L "$OMNI_BASE_URL/api/v1/documents?creatorId={userId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents list --creator-id <userId>
 ```
 
 Each document includes: `identifier`, `name`, `type`, `scope`, `owner`, `folder`, `labels`, `updatedAt`, `hasDashboard`.
@@ -91,8 +83,7 @@ Each document includes: `identifier`, `name`, `type`, `scope`, `owner`, `folder`
 Retrieve query definitions powering a dashboard's tiles:
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/documents/{identifier}/queries" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents get-queries <identifier>
 ```
 
 Useful for understanding what a dashboard computes and re-running queries via `omni-query`.
@@ -101,56 +92,43 @@ Useful for understanding what a dashboard computes and re-running queries via `o
 
 ```bash
 # List
-curl -L "$OMNI_BASE_URL/api/v1/folders" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni folders list
 
 # Create
-curl -L -X POST "$OMNI_BASE_URL/api/v1/folders" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "name": "Q1 Reports", "scope": "organization" }'
+omni folders create --body '{ "name": "Q1 Reports", "scope": "organization" }'
 ```
 
 ## Labels
 
 ```bash
 # List labels
-curl -L "$OMNI_BASE_URL/api/v1/labels" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni labels list
 
 # Add label to document
-curl -L -X PUT "$OMNI_BASE_URL/api/v1/documents/{identifier}/labels/{labelName}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents add-label <identifier> <labelName>
 
 # Remove label
-curl -L -X DELETE "$OMNI_BASE_URL/api/v1/documents/{identifier}/labels/{labelName}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents remove-label <identifier> <labelName>
 ```
 
 ## Favorites
 
 ```bash
 # Favorite
-curl -L -X PUT "$OMNI_BASE_URL/api/v1/documents/{identifier}/favorite" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents add-favorite <identifier>
 
 # Unfavorite
-curl -L -X DELETE "$OMNI_BASE_URL/api/v1/documents/{identifier}/favorite" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents remove-favorite <identifier>
 ```
 
 ## Dashboard Downloads
 
 ```bash
 # Start download (async)
-curl -L -X POST "$OMNI_BASE_URL/api/v1/dashboards/{dashboardId}/download" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "format": "pdf" }'
+omni dashboards download <dashboardId> --body '{ "format": "pdf" }'
 
 # Poll job status
-curl -L "$OMNI_BASE_URL/api/v1/dashboards/{dashboardId}/download/{jobId}/status" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni dashboards download-status <dashboardId> <jobId>
 ```
 
 Formats: `pdf`, `png`
@@ -168,7 +146,7 @@ The `identifier` comes from the document's `identifier` field in API responses. 
 
 ## Search Patterns
 
-When scanning all documents for field references (e.g., for impact analysis), paginate with cursor and call `GET /api/v1/documents/{identifier}/queries` for each document. Launch multiple query-fetch calls in parallel for efficiency. For field impact analysis, prefer the content-validator approach in `omni-model-explorer`.
+When scanning all documents for field references (e.g., for impact analysis), paginate with cursor and call `omni documents get-queries <identifier>` for each document. Launch multiple query-fetch calls in parallel for efficiency. For field impact analysis, prefer the content-validator approach in `omni-model-explorer`.
 
 ## Docs Reference
 

--- a/skills/omni-content-explorer/SKILL.md
+++ b/skills/omni-content-explorer/SKILL.md
@@ -10,14 +10,8 @@ Find, browse, and organize Omni content â€” dashboards, workbooks, and folders â
 ## Prerequisites
 
 ```bash
-# Install the CLI (macOS / Linux)
-curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
-
-# Configure authentication
-omni config init
+command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 ```
-
-Or set environment variables instead of using `omni config init`:
 
 ```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"

--- a/skills/omni-content-explorer/SKILL.md
+++ b/skills/omni-content-explorer/SKILL.md
@@ -10,10 +10,16 @@ Find, browse, and organize Omni content â€” dashboards, workbooks, and folders â
 ## Prerequisites
 
 ```bash
-# Option 1: Interactive profile setup (recommended)
-omni config init
+# Install the CLI (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 
-# Option 2: Environment variables
+# Configure authentication
+omni config init
+```
+
+Or set environment variables instead of using `omni config init`:
+
+```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
 export OMNI_API_TOKEN="your-api-key"
 ```

--- a/skills/omni-embed/SKILL.md
+++ b/skills/omni-embed/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omni-embed
-description: Embed Omni Analytics dashboards in external applications — URL signing, custom themes, iframe events, entity workspaces, and permission-aware content — using the @omni-co/embed SDK and REST API. Use this skill whenever someone wants to embed a dashboard, sign an embed URL, customize the embedded theme, handle embed events, listen for clicks or drills in the iframe, send filters to an embedded dashboard, set up entity workspaces, look up embed users, build a permission-aware content list, white-label an embedded dashboard, or any variant of "embed this dashboard", "customize the iframe theme", "handle click events from the embed", "filter the embedded dashboard", "set up embedding", or "what dashboards can this user see".
+description: Embed Omni Analytics dashboards in external applications — URL signing, custom themes, iframe events, entity workspaces, and permission-aware content — using the @omni-co/embed SDK and Omni CLI. Use this skill whenever someone wants to embed a dashboard, sign an embed URL, customize the embedded theme, handle embed events, listen for clicks or drills in the iframe, send filters to an embedded dashboard, set up entity workspaces, look up embed users, build a permission-aware content list, white-label an embedded dashboard, or any variant of "embed this dashboard", "customize the iframe theme", "handle click events from the embed", "filter the embedded dashboard", "set up embedding", or "what dashboards can this user see".
 ---
 
 # Omni Embed
@@ -16,23 +16,25 @@ npm install @omni-co/embed
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.embed-omniapp.co"   # Embed domain
-export OMNI_EMBED_SECRET="your-embed-secret"               # Admin → Embed
-export OMNI_API_KEY="your-api-key"                         # For user/content API calls
+# For the Omni CLI (API calls use the standard .omniapp.co domain):
+omni config init
+# Or set environment variables:
+export OMNI_BASE_URL="https://yourorg.omniapp.co"
+export OMNI_API_TOKEN="your-api-key"
+
+# For embed URL signing (uses the .embed-omniapp.co domain):
+export OMNI_EMBED_SECRET="your-embed-secret"   # Admin → Embed
 ```
 
 The embed secret is found in **Admin → Embed** in your Omni instance. The `OMNI_BASE_URL` for embedding uses the `.embed-omniapp.co` domain, not the standard `.omniapp.co` domain.
 
-## API Discovery
-
-When unsure whether an endpoint or parameter exists, fetch the OpenAPI spec:
+## Discovering Commands
 
 ```bash
-curl -L "$OMNI_BASE_URL/openapi.json" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni scim --help        # Embed user lookup
+omni documents --help   # Document listing
+omni folders --help     # Folder listing
 ```
-
-Use this to verify endpoints, available parameters, and request/response schemas before making calls.
 
 ## Signing Embed URLs
 
@@ -372,8 +374,7 @@ When building permission-aware experiences (e.g., a sidebar that only shows dash
 ### Look Up an Embed User
 
 ```bash
-curl -L "$OMNI_API_BASE/api/scim/v2/embed/users?filter=embedExternalId%20eq%20%22user@example.com%22" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni scim embed-users-list --filter 'embedExternalId eq "user@example.com"'
 ```
 
 Returns the Omni user ID for the given `externalId`. If no user is found, the user hasn't accessed any embedded dashboards yet.
@@ -381,8 +382,7 @@ Returns the Omni user ID for the given `externalId`. If no user is found, the us
 ### List Documents by User Permission
 
 ```bash
-curl -L "$OMNI_API_BASE/api/v1/documents?userId={omniUserId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents list --user-id <omniUserId>
 ```
 
 Response uses `records` array (not `documents`):
@@ -417,8 +417,7 @@ Use `identifier` as the `contentId` for embed signing. Filter for `hasDashboard:
 Entity folders have technical paths like `omni-system-sso-embed-entity-folder-poc`. Map paths to display names:
 
 ```bash
-curl -L "$OMNI_API_BASE/api/v1/folders" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni folders list
 ```
 
 Build a `path → name` mapping from the response to display user-friendly folder names.

--- a/skills/omni-embed/SKILL.md
+++ b/skills/omni-embed/SKILL.md
@@ -16,7 +16,10 @@ npm install @omni-co/embed
 ```
 
 ```bash
-# For the Omni CLI (API calls use the standard .omniapp.co domain):
+# Install the Omni CLI (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+
+# Configure the CLI (API calls use the standard .omniapp.co domain):
 omni config init
 # Or set environment variables:
 export OMNI_BASE_URL="https://yourorg.omniapp.co"

--- a/skills/omni-embed/SKILL.md
+++ b/skills/omni-embed/SKILL.md
@@ -16,17 +16,13 @@ npm install @omni-co/embed
 ```
 
 ```bash
-# Install the Omni CLI (macOS / Linux)
-curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+```
 
-# Configure the CLI (API calls use the standard .omniapp.co domain):
-omni config init
-# Or set environment variables:
+```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
 export OMNI_API_TOKEN="your-api-key"
-
-# For embed URL signing (uses the .embed-omniapp.co domain):
-export OMNI_EMBED_SECRET="your-embed-secret"   # Admin → Embed
+export OMNI_EMBED_SECRET="your-embed-secret"   # Admin → Embed (for URL signing)
 ```
 
 The embed secret is found in **Admin → Embed** in your Omni instance. The `OMNI_BASE_URL` for embedding uses the `.embed-omniapp.co` domain, not the standard `.omniapp.co` domain.

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -96,15 +96,8 @@ Always work in a branch. Never write directly to production.
 
 ### Step 0: Create a Branch
 
-Omni branches are models with `modelKind: "BRANCH"`. There is no dedicated branch-creation endpoint — create one via `POST /api/v1/models`:
-
 ```bash
-omni models create --body '{
-  "modelKind": "BRANCH",
-  "baseModelId": "{sharedModelId}",
-  "connectionId": "{connectionId}",
-  "modelName": "my-feature-branch"
-}'
+omni models create-branch <modelId> --name "my-feature-branch"
 ```
 
 The response `model.id` is your `branchId` — a UUID you'll pass to all subsequent API calls. To list existing branches at any time:

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -12,10 +12,16 @@ Create and modify Omni's semantic model through the YAML API — views, topics, 
 ## Prerequisites
 
 ```bash
-# Option 1: Interactive profile setup (recommended)
-omni config init
+# Install the CLI (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 
-# Option 2: Environment variables
+# Configure authentication
+omni config init
+```
+
+Or set environment variables instead of using `omni config init`:
+
+```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
 export OMNI_API_TOKEN="your-api-key"
 ```

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omni-model-builder
-description: Create and edit Omni Analytics semantic model definitions — views, topics, dimensions, measures, relationships, and query views — using YAML through the Omni REST API. Use this skill whenever someone wants to add a field, create a new dimension or measure, define a topic, set up joins between tables, modify the data model, build a new view, add a calculated field, create a relationship, edit YAML, work on a branch, promote model changes, or any variant of "model this data", "add this metric", "create a view for", or "set up a join between". Also use for migrating modeling patterns since Omni's YAML is conceptually similar to other semantic layer definitions.
+description: Create and edit Omni Analytics semantic model definitions — views, topics, dimensions, measures, relationships, and query views — using YAML through the Omni CLI. Use this skill whenever someone wants to add a field, create a new dimension or measure, define a topic, set up joins between tables, modify the data model, build a new view, add a calculated field, create a relationship, edit YAML, work on a branch, promote model changes, or any variant of "model this data", "add this metric", "create a view for", or "set up a join between". Also use for migrating modeling patterns since Omni's YAML is conceptually similar to other semantic layer definitions.
 ---
 
 # Omni Model Builder
@@ -12,8 +12,12 @@ Create and modify Omni's semantic model through the YAML API — views, topics, 
 ## Prerequisites
 
 ```bash
+# Option 1: Interactive profile setup (recommended)
+omni config init
+
+# Option 2: Environment variables
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_KEY="your-api-key"
+export OMNI_API_TOKEN="your-api-key"
 ```
 
 You need **Modeler** or **Connection Admin** permissions.
@@ -39,13 +43,11 @@ Omni uses a **layered approach** where each layer builds on top of the previous:
 Before writing any SQL expressions, confirm the dialect from the connection — don't guess from the connection name:
 
 ```bash
-# 1. Get the model's connectionId
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+# 1. List models to find connectionId
+omni models list
 
 # 2. Look up the connection's dialect
-curl -L "$OMNI_BASE_URL/api/v1/connections" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni connections list
 # → find your connectionId and read the "dialect" field
 # → e.g. "bigquery", "postgres", "snowflake", "databricks"
 ```
@@ -73,26 +75,20 @@ The **schema layer** is auto-generated from your database. When your database sc
 **Trigger via API:**
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/models/{modelId}/refresh" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models refresh <modelId>
 
 # With branch:
-curl -L -X POST "$OMNI_BASE_URL/api/v1/models/{modelId}/refresh?branch_id={branchId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models refresh <modelId> --branch-id <branchId>
 ```
 
 Requires **Connection Admin** permissions.
 
-## API Discovery
-
-When unsure whether an endpoint or parameter exists, fetch the OpenAPI spec:
+## Discovering Commands
 
 ```bash
-curl -L "$OMNI_BASE_URL/openapi.json" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models --help              # List all model operations
+omni models yaml-create --help  # Show flags for writing YAML
 ```
-
-Use this to verify endpoints, available parameters, and request/response schemas before making calls.
 
 ## Safe Development Workflow
 
@@ -103,39 +99,32 @@ Always work in a branch. Never write directly to production.
 Omni branches are models with `modelKind: "BRANCH"`. There is no dedicated branch-creation endpoint — create one via `POST /api/v1/models`:
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/models" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "modelKind": "BRANCH",
-    "baseModelId": "{sharedModelId}",
-    "connectionId": "{connectionId}",
-    "modelName": "my-feature-branch"
-  }'
+omni models create --body '{
+  "modelKind": "BRANCH",
+  "baseModelId": "{sharedModelId}",
+  "connectionId": "{connectionId}",
+  "modelName": "my-feature-branch"
+}'
 ```
 
 The response `model.id` is your `branchId` — a UUID you'll pass to all subsequent API calls. To list existing branches at any time:
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/models?include=activeBranches" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models list --include activeBranches
 ```
 
-> **Git-connected models**: If your model is connected to a git repo (`GET /api/v1/models/{modelId}/git` returns an `sshUrl`), merging an Omni branch will automatically commit the changes back to your git `baseBranch`. Choose one workflow and stick to it — either edit via the Omni branch API (then `git pull` to sync local files), or edit local files and push via git. Mixing both leads to conflicts.
+> **Git-connected models**: If your model is connected to a git repo (`omni models git-get <modelId>` returns an `sshUrl`), merging an Omni branch will automatically commit the changes back to your git `baseBranch`. Choose one workflow and stick to it — either edit via the Omni branch API (then `git pull` to sync local files), or edit local files and push via git. Mixing both leads to conflicts.
 
 ### Step 1: Write YAML to a Branch
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/models/{modelId}/yaml" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "fileName": "my_new_view.view",
-    "yaml": "dimensions:\n  order_id:\n    primary_key: true\n  status:\n    label: Order Status\nmeasures:\n  count:\n    aggregate_type: count",
-    "mode": "extension",
-    "branchId": "{branchId}",
-    "commitMessage": "Add my_new_view with status dimension and count measure"
-  }'
+omni models yaml-create <modelId> --body '{
+  "fileName": "my_new_view.view",
+  "yaml": "dimensions:\n  order_id:\n    primary_key: true\n  status:\n    label: Order Status\nmeasures:\n  count:\n    aggregate_type: count",
+  "mode": "extension",
+  "branchId": "{branchId}",
+  "commitMessage": "Add my_new_view with status dimension and count measure"
+}'
 ```
 
 > **Note**: The `branchId` parameter must be a UUID from the server (Step 0). Passing a string name instead will return `400 Bad Request: Unrecognized key: "branchName"`.
@@ -143,8 +132,7 @@ curl -L -X POST "$OMNI_BASE_URL/api/v1/models/{modelId}/yaml" \
 ### Step 2: Validate
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/validate?branchId={branchId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models validate <modelId> --branch-id <branchId>
 ```
 
 Returns validation errors and warnings with `message`, `yaml_path`, and sometimes `auto_fix`.
@@ -154,8 +142,7 @@ Returns validation errors and warnings with `message`, `yaml_path`, and sometime
 > **Important**: Always ask the user for confirmation before merging. Merging applies changes to the production model and cannot be easily undone.
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/models/{modelId}/branch/{branchName}/merge" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models merge-branch <modelId> <branchName>
 ```
 
 If git with required PRs is configured, merge through your git workflow instead.
@@ -344,8 +331,7 @@ sql: |
 If your model doesn't reflect the database (missing columns, broken references, wrong types), trigger a schema refresh (see "Schema Refresh" section above). Then validate:
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/validate" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models validate <modelId>
 ```
 
 Common issues and fixes:

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -12,14 +12,8 @@ Create and modify Omni's semantic model through the YAML API — views, topics, 
 ## Prerequisites
 
 ```bash
-# Install the CLI (macOS / Linux)
-curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
-
-# Configure authentication
-omni config init
+command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 ```
-
-Or set environment variables instead of using `omni config init`:
 
 ```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -14,10 +14,16 @@ Explore and understand an Omni semantic model through the Omni CLI. This is the 
 Configure the Omni CLI:
 
 ```bash
-# Option 1: Interactive profile setup (recommended)
-omni config init
+# Install the CLI (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 
-# Option 2: Environment variables
+# Configure authentication
+omni config init
+```
+
+Or set environment variables instead of using `omni config init`:
+
+```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
 export OMNI_API_TOKEN="your-api-key"
 ```

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -14,14 +14,8 @@ Explore and understand an Omni semantic model through the Omni CLI. This is the 
 Configure the Omni CLI:
 
 ```bash
-# Install the CLI (macOS / Linux)
-curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
-
-# Configure authentication
-omni config init
+command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 ```
-
-Or set environment variables instead of using `omni config init`:
 
 ```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -1,35 +1,37 @@
 ---
 name: omni-model-explorer
-description: Discover and inspect Omni Analytics models, topics, views, fields, dimensions, measures, and relationships using the Omni REST API. Use this skill whenever someone wants to understand what data is available in Omni, explore their semantic model, find specific fields or views, check how tables join together, see what topics exist, or asks any variant of "what can I query", "what fields are available", "show me the model", "what data do we have", or "how is this data modeled". Also use when you need to understand the Omni model structure before building or modifying anything.
+description: Discover and inspect Omni Analytics models, topics, views, fields, dimensions, measures, and relationships using the Omni CLI. Use this skill whenever someone wants to understand what data is available in Omni, explore their semantic model, find specific fields or views, check how tables join together, see what topics exist, or asks any variant of "what can I query", "what fields are available", "show me the model", "what data do we have", or "how is this data modeled". Also use when you need to understand the Omni model structure before building or modifying anything.
 ---
 
 # Omni Model Explorer
 
-Explore and understand an Omni semantic model through the REST API. This is the starting point — understand what exists before building, querying, or modifying anything.
+Explore and understand an Omni semantic model through the Omni CLI. This is the starting point — understand what exists before building, querying, or modifying anything.
 
 > **Tip**: Start with the **Shared** model — it contains the curated analytics layer.
 
 ## Prerequisites
 
-Set environment variables:
+Configure the Omni CLI:
 
 ```bash
+# Option 1: Interactive profile setup (recommended)
+omni config init
+
+# Option 2: Environment variables
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_KEY="your-api-key"
+export OMNI_API_TOKEN="your-api-key"
 ```
 
 API keys: Settings > API Keys (Organization Admin) or User Profile > Manage Account > Generate Token (Personal Access Token).
 
-## API Discovery
+## Discovering Commands
 
-When unsure whether an endpoint or parameter exists, fetch the OpenAPI spec:
+When unsure what operations or flags are available:
 
 ```bash
-curl -L "$OMNI_BASE_URL/openapi.json" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models --help              # List all model operations
+omni models <operation> --help  # Show flags and positional args
 ```
-
-Use this to verify endpoints, available parameters, and request/response schemas before making calls.
 
 ## Core Workflow
 
@@ -38,8 +40,7 @@ Explore top-down: **List models → Pick a model → List topics → Inspect a t
 ### Step 1: List Available Models
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/models" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models list
 ```
 
 Returns models with `id`, `name`, `connectionId`, and `modelKind` (SCHEMA or SHARED). Use the SHARED model — it contains the curated semantic layer.
@@ -47,8 +48,7 @@ Returns models with `id`, `name`, `connectionId`, and `modelKind` (SCHEMA or SHA
 To also see active branches on each model:
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/models?include=activeBranches" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models list --include activeBranches
 ```
 
 Each model in the response will include a `branches` array. Each branch has an `id` (UUID) and `name` — use the `id` as the `branchId` parameter in other API calls.
@@ -58,8 +58,7 @@ Each model in the response will include a `branches` array. Each branch has an `
 Topics are entry points for querying. Each topic defines a base view and the set of joined views available.
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/topic" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models list-topics <modelId>
 ```
 
 Returns topic names, base views, labels, and descriptions.
@@ -69,8 +68,7 @@ Returns topic names, base views, labels, and descriptions.
 Get full detail including all views, dimensions, measures, relationships, and AI context:
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/topic/{topicName}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models get-topic <modelId> <topicName>
 ```
 
 The response includes:
@@ -86,20 +84,16 @@ For the full semantic model definition:
 
 ```bash
 # All YAML files
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/yaml" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models yaml-get <modelId>
 
 # Specific file
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/yaml?fileName=order_items.view" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models yaml-get <modelId> --file-name order_items.view
 
 # Regex filter
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/yaml?fileName=.*sales.*" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models yaml-get <modelId> --file-name '.*sales.*'
 
 # From a branch (branchId is a UUID from the list models response)
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/yaml?branchId={branchId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models yaml-get <modelId> --branch-id <branchId>
 ```
 
 The `mode` parameter: `combined` (default) merges schema + shared model; `extension` shows only shared model customizations.
@@ -144,8 +138,7 @@ Assess the blast radius of a field migration or removal before pushing changes t
 2. **Run the content validator** against that branch:
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/content-validator?branchId={branchId}" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models content-validator-get <modelId> --branch-id <branchId>
 ```
 
 This returns all dashboards and tiles with broken references to the removed field.
@@ -153,8 +146,7 @@ This returns all dashboards and tiles with broken references to the removed fiel
 3. **Search model YAML** for additional references (run in parallel with step 2):
 
 ```bash
-curl -L "$OMNI_BASE_URL/api/v1/models/{modelId}/yaml?fileName=.*" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni models yaml-get <modelId> --file-name '.*'
 ```
 
 Search the response for the field name to find references in other views, topics, and calculated fields.

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -12,10 +12,16 @@ Run queries against Omni's semantic layer via the Omni CLI. Omni translates fiel
 ## Prerequisites
 
 ```bash
-# Option 1: Interactive profile setup (recommended)
-omni config init
+# Install the CLI (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 
-# Option 2: Environment variables
+# Configure authentication
+omni config init
+```
+
+Or set environment variables instead of using `omni config init`:
+
+```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
 export OMNI_API_TOKEN="your-api-key"
 ```

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -12,14 +12,8 @@ Run queries against Omni's semantic layer via the Omni CLI. Omni translates fiel
 ## Prerequisites
 
 ```bash
-# Install the CLI (macOS / Linux)
-curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
-
-# Configure authentication
-omni config init
+command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
 ```
-
-Or set environment variables instead of using `omni config init`:
 
 ```bash
 export OMNI_BASE_URL="https://yourorg.omniapp.co"

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -33,6 +33,7 @@ You also need a **model ID** and knowledge of available **topics and fields**.
 ```bash
 omni query --help              # List query operations
 omni query run --help          # Show flags for running a query
+omni ai --help                 # AI-powered query generation
 ```
 
 ## Running a Query
@@ -153,6 +154,95 @@ omni query run --body '{ "query": { ... }, "userId": "user-uuid-here" }'
 omni query run --body '{ "query": { ... }, "cache": "SkipCache" }'
 ```
 
+## AI-Powered Query Generation
+
+Instead of constructing query JSON manually, you can describe what you want in natural language and let Omni's AI generate the query.
+
+### Generate Query (synchronous)
+
+The fastest path — returns a generated query JSON synchronously. Set `runQuery: false` to get only the query structure without executing it, or `true` (default) to also run it against the database.
+
+```bash
+# Just generate the query JSON (no execution)
+omni ai generate-query --body '{
+  "modelId": "your-model-id",
+  "prompt": "Show me revenue by month",
+  "runQuery": false
+}'
+```
+
+Response:
+
+```json
+{
+  "query": {
+    "fields": ["order_items.created_at[month]", "order_items.total_revenue"],
+    "table": "order_items",
+    "filters": {},
+    "sorts": [{"column_name": "order_items.created_at[month]", "sort_descending": false}],
+    "limit": 500
+  },
+  "topic": "order_items",
+  "error": null
+}
+```
+
+```bash
+# Generate and execute in one call
+omni ai generate-query --body '{
+  "modelId": "your-model-id",
+  "prompt": "Top 10 customers by lifetime spend"
+}'
+```
+
+Optional parameters:
+- `branchId` — test against a specific model branch
+- `currentTopicName` — constrain topic selection to a specific topic
+
+### Pick Topic
+
+Check which topic the AI would select for a question, without generating a full query:
+
+```bash
+omni ai pick-topic --body '{
+  "modelId": "your-model-id",
+  "prompt": "How many users signed up last month?"
+}'
+```
+
+### Agentic Queries (async)
+
+For the full Blobby experience — multi-step analysis, tool use, and topic selection as the AI would actually behave in production. This is async: submit a job, poll for status, then retrieve the result.
+
+```bash
+# 1. Submit a job
+omni ai job-submit --body '{
+  "modelId": "your-model-id",
+  "prompt": "Analyze revenue trends and identify our fastest growing product category"
+}'
+# → returns { "jobId": "job-uuid", "conversationId": "conv-uuid" }
+
+# 2. Poll for completion (QUEUED → EXECUTING → COMPLETE)
+omni ai job-status <jobId>
+
+# 3. Get the result
+omni ai job-result <jobId>
+```
+
+The result contains an `actions` array with each step the AI took — look for actions with `type: "generate_query"` to extract the generated queries. The response also includes `resultSummary` with the AI's narrative interpretation.
+
+Additional job commands:
+- `omni ai job-cancel <jobId>` — cancel a running job
+- `omni ai job-visualization <jobId>` — get the visualization output
+
+### When to Use Which Approach
+
+| Approach | Best For |
+|----------|----------|
+| `omni query run` | You know exactly which fields, filters, and sorts you need |
+| `omni ai generate-query` | Translating a natural language question into a single query |
+| `omni ai job-submit` | Complex questions that may need multiple queries or multi-step reasoning |
+
 ## Multi-Step Analysis Pattern
 
 For complex analysis, chain queries:
@@ -191,3 +281,4 @@ Queries are ephemeral — there is no persistent URL for a query result. To give
 - **omni-model-explorer** — discover fields and topics before querying
 - **omni-content-explorer** — find dashboards whose queries you can extract
 - **omni-content-builder** — turn query results into dashboards
+- **omni-eval** — benchmark and test AI query generation accuracy

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -1,54 +1,51 @@
 ---
 name: omni-query
-description: Run queries against Omni Analytics' semantic layer using the REST API, interpret results, and chain queries for multi-step analysis. Use this skill whenever someone wants to query data through Omni, run a report, get metrics, pull numbers, analyze data, ask "how many", "what's the trend", "show me the data", retrieve dashboard query results, or perform any data retrieval through Omni's query engine. Also use when someone wants to programmatically extract data from an existing Omni dashboard or workbook.
+description: Run queries against Omni Analytics' semantic layer using the Omni CLI, interpret results, and chain queries for multi-step analysis. Use this skill whenever someone wants to query data through Omni, run a report, get metrics, pull numbers, analyze data, ask "how many", "what's the trend", "show me the data", retrieve dashboard query results, or perform any data retrieval through Omni's query engine. Also use when someone wants to programmatically extract data from an existing Omni dashboard or workbook.
 ---
 
 # Omni Query
 
-Run queries against Omni's semantic layer via the REST API. Omni translates field selections into optimized SQL — you specify what you want (dimensions, measures, filters), not how to get it.
+Run queries against Omni's semantic layer via the Omni CLI. Omni translates field selections into optimized SQL — you specify what you want (dimensions, measures, filters), not how to get it.
 
 > **Tip**: Use `omni-model-explorer` first if you don't know the available topics and fields.
 
 ## Prerequisites
 
 ```bash
+# Option 1: Interactive profile setup (recommended)
+omni config init
+
+# Option 2: Environment variables
 export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_KEY="your-api-key"
+export OMNI_API_TOKEN="your-api-key"
 ```
 
 You also need a **model ID** and knowledge of available **topics and fields**.
 
-## API Discovery
-
-When unsure whether an endpoint or parameter exists, fetch the OpenAPI spec:
+## Discovering Commands
 
 ```bash
-curl -L "$OMNI_BASE_URL/openapi.json" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni query --help              # List query operations
+omni query run --help          # Show flags for running a query
 ```
-
-Use this to verify endpoints, available parameters, and request/response schemas before making calls.
 
 ## Running a Query
 
 ### Basic Query
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/query/run" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": {
-      "modelId": "your-model-id",
-      "table": "order_items",
-      "fields": [
-        "order_items.created_at[month]",
-        "order_items.total_revenue"
-      ],
-      "limit": 100,
-      "join_paths_from_topic_name": "order_items"
-    }
-  }'
+omni query run --body '{
+  "query": {
+    "modelId": "your-model-id",
+    "table": "order_items",
+    "fields": [
+      "order_items.created_at[month]",
+      "order_items.total_revenue"
+    ],
+    "limit": 100,
+    "join_paths_from_topic_name": "order_items"
+  }
+}'
 ```
 
 ### Query Parameters
@@ -132,10 +129,7 @@ df = reader.read_all().to_pandas()
 If the response includes `remaining_job_ids`, poll until complete:
 
 ```bash
-curl -L -X POST "$OMNI_BASE_URL/api/v1/query/wait" \
-  -H "Authorization: Bearer $OMNI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "jobIds": ["job-id-1", "job-id-2"] }'
+omni query wait --job-ids job-id-1,job-id-2
 ```
 
 ## Running Queries from Dashboards
@@ -144,14 +138,13 @@ Extract and re-run queries powering existing dashboards:
 
 ```bash
 # Get all queries from a dashboard
-curl -L "$OMNI_BASE_URL/api/v1/documents/{dashboardId}/queries" \
-  -H "Authorization: Bearer $OMNI_API_KEY"
+omni documents get-queries <dashboardId>
 
 # Run as a specific user
-{ "query": { ... }, "userId": "user-uuid-here" }
+omni query run --body '{ "query": { ... }, "userId": "user-uuid-here" }'
 
 # Cache policy (valid values: Standard, SkipRequery, SkipCache)
-{ "query": { ... }, "cache": "SkipCache" }
+omni query run --body '{ "query": { ... }, "cache": "SkipCache" }'
 ```
 
 ## Multi-Step Analysis Pattern


### PR DESCRIPTION
## Summary
- Migrate all API examples from raw `curl` commands to the new [Omni CLI](https://github.com/exploreomni/cli) (`omni`) across 15 files — 8 skills, 3 agents, 3 rules, and the README
- Replace ~70+ curl commands with equivalent `omni` CLI commands (e.g., `curl -L "$OMNI_BASE_URL/api/v1/models" -H "Authorization: Bearer $OMNI_API_KEY"` → `omni models list`)
- Update auth setup from `OMNI_API_KEY` env var to `OMNI_API_TOKEN` / `omni config init`
- Replace API Discovery sections (`curl openapi.json`) with `omni <group> --help` guidance
- Rewrite `omni-api-conventions` rule from curl-centric to CLI-centric
- One intentional curl exception: `PUT /api/v1/documents/{id}` (full document replacement) — not yet in the OpenAPI spec

## Test plan
- [ ] Verify all `omni` commands referenced match CLI help output (`omni <group> <op> --help`)
- [ ] Grep for remaining `curl` references (only the documented PUT exception should remain)
- [ ] Grep for `OMNI_API_KEY` — should be zero matches
- [ ] Spot-check `--body` JSON payloads are preserved correctly from original curl `-d` args
- [ ] Review the `omni-api-conventions` rule rewrite for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)