### PR TITLE
Rebrand AI assistant / query helper terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ These activate from natural-language requests:
 | **omni-query** | Run queries against Omni's semantic layer and interpret results |
 | **omni-content-explorer** | Find, browse, and organize dashboards, workbooks, and folders |
 | **omni-content-builder** | Create, update, and manage documents and dashboards programmatically - lifecycle, tiles, filters, layouts |
-| **omni-ai-optimizer** | Optimize your Omni model for Blobby, Omni's AI assistant |
+| **omni-ai-optimizer** | Optimize your Omni model for Blobby, the Omni Agent |
 | **omni-admin** | Manage connections, users, groups, permissions, schedules, and schema refreshes |
 | **omni-embed** | Embed Omni dashboards in external applications - URL signing, themes, and postMessage events |
 | **omni-ai-eval** | Evaluate AI query generation accuracy — run test prompts, compare results, and score across dimensions |

--- a/agents/omni-modeler.md
+++ b/agents/omni-modeler.md
@@ -5,7 +5,7 @@ description: Omni Analytics data modeler — builds and refines the semantic mod
 
 # Omni Modeler
 
-You are a senior analytics engineer building Omni's semantic model. Your job is to write clean, correct YAML definitions and optimize the model for both human analysts and Blobby (Omni's AI assistant).
+You are a senior analytics engineer building Omni's semantic model. Your job is to write clean, correct YAML definitions and optimize the model for both human analysts and Blobby (the Omni Agent).
 
 ## Workflow
 

--- a/rules/omni-terminology.mdc
+++ b/rules/omni-terminology.mdc
@@ -18,7 +18,7 @@ alwaysApply: false
 | **Relationship** | A join definition between two views |
 | **Workbook** | An interactive analysis document |
 | **Dashboard** | Published, shareable view of a workbook |
-| **Blobby** | Omni's built-in agent (the Omni Agent) |
+| **Blobby** | Omni's built-in agent |
 | **Query View** | Virtual table defined by a saved query |
 | **Branch** | Development branch for model changes |
 | **User Attribute** | Per-user value for row-level security |

--- a/rules/omni-terminology.mdc
+++ b/rules/omni-terminology.mdc
@@ -18,7 +18,7 @@ alwaysApply: false
 | **Relationship** | A join definition between two views |
 | **Workbook** | An interactive analysis document |
 | **Dashboard** | Published, shareable view of a workbook |
-| **Blobby** | Omni's built-in AI assistant |
+| **Blobby** | Omni's built-in agent (the Omni Agent) |
 | **Query View** | Virtual table defined by a saved query |
 | **Branch** | Development branch for model changes |
 | **User Attribute** | Per-user value for row-level security |

--- a/skills/omni-ai-optimizer/SKILL.md
+++ b/skills/omni-ai-optimizer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: omni-ai-optimizer
-description: Optimize your Omni Analytics model for Blobby, Omni's AI assistant — configure ai_context, ai_fields, sample_queries, and create AI-specific topic extensions. Use this skill whenever someone wants to improve AI accuracy in Omni, make Blobby smarter, configure AI context, add example questions, tune AI responses, set up sample queries, curate fields for AI, create AI-optimized topics, troubleshoot why Blobby gives wrong answers, or any variant of "make the AI better", "Blobby isn't answering correctly", "add context for AI", "optimize for AI", or "teach the AI about our data".
+description: Optimize your Omni Analytics model for Blobby, the Omni Agent — configure ai_context, ai_fields, sample_queries, and create AI-specific topic extensions. Use this skill whenever someone wants to improve AI accuracy in Omni, make Blobby smarter, configure AI context, add example questions, tune AI responses, set up sample queries, curate fields for AI, create AI-optimized topics, troubleshoot why Blobby gives wrong answers, or any variant of "make the AI better", "Blobby isn't answering correctly", "add context for AI", "optimize for AI", or "teach the AI about our data".
 ---
 
 # Omni AI Optimizer
 
-Optimize your Omni semantic model so Blobby (Omni's AI assistant) returns accurate, contextual answers.
+Optimize your Omni semantic model so Blobby (the Omni Agent) returns accurate, contextual answers.
 
 > **Tip**: Use `omni-model-explorer` to inspect current AI context before making changes.
 

--- a/skills/omni-model-builder/references/modelParameters.md
+++ b/skills/omni-model-builder/references/modelParameters.md
@@ -16,8 +16,8 @@ Complete parameter reference for views, topics, dimensions, and measures. Use th
 | `group_label` | Groups fields in the picker |
 | `tags` | Metadata for field search and curation (e.g., `[internal, pii]`) |
 | `synonyms` | Alternative names for AI matching (e.g., `[client, account, buyer]`) |
-| `ai_context` | Free text providing context to the AI query helper |
-| `all_values` | Complete list of possible values for AI helper |
+| `ai_context` | Free text providing context to the Workbook Agent |
+| `all_values` | Complete list of possible values for the Workbook Agent |
 | `sample_values` | Representative values for AI content understanding |
 | `display_order` | Overrides sort order in field picker |
 | `view_label` | Nests field under a different view in the picker |
@@ -94,8 +94,8 @@ dimensions:
 | `group_label` | Groups fields in the picker |
 | `tags` | Metadata for field search and curation |
 | `synonyms` | Alternative names for AI matching |
-| `ai_context` | Free text providing context to the AI query helper |
-| `all_values` | Complete list of possible values for AI helper |
+| `ai_context` | Free text providing context to the Workbook Agent |
+| `all_values` | Complete list of possible values for the Workbook Agent |
 | `sample_values` | Sample values for AI to understand magnitude |
 | `filters` | Filtered aggregations (see Measure Filters below) |
 | `custom_primary_key_sql` | Custom dedup key for `*_distinct_on` aggregate types |

--- a/skills/omni-model-builder/references/modelParameters.md
+++ b/skills/omni-model-builder/references/modelParameters.md
@@ -16,8 +16,8 @@ Complete parameter reference for views, topics, dimensions, and measures. Use th
 | `group_label` | Groups fields in the picker |
 | `tags` | Metadata for field search and curation (e.g., `[internal, pii]`) |
 | `synonyms` | Alternative names for AI matching (e.g., `[client, account, buyer]`) |
-| `ai_context` | Free text providing context to the Workbook Agent |
-| `all_values` | Complete list of possible values for the Workbook Agent |
+| `ai_context` | Free text providing context to the Omni Agent |
+| `all_values` | Complete list of possible values for the Omni Agent |
 | `sample_values` | Representative values for AI content understanding |
 | `display_order` | Overrides sort order in field picker |
 | `view_label` | Nests field under a different view in the picker |
@@ -94,8 +94,8 @@ dimensions:
 | `group_label` | Groups fields in the picker |
 | `tags` | Metadata for field search and curation |
 | `synonyms` | Alternative names for AI matching |
-| `ai_context` | Free text providing context to the Workbook Agent |
-| `all_values` | Complete list of possible values for the Workbook Agent |
+| `ai_context` | Free text providing context to the Omni Agent |
+| `all_values` | Complete list of possible values for the Omni Agent |
 | `sample_values` | Sample values for AI to understand magnitude |
 | `filters` | Filtered aggregations (see Measure Filters below) |
 | `custom_primary_key_sql` | Custom dedup key for `*_distinct_on` aggregate types |


### PR DESCRIPTION
## Summary
- "AI assistant" → "Omni Agent" in 5 places (Blobby name preserved, only the descriptor updated)
- "AI query helper" / "AI helper" → "Workbook Agent" in 4 places (modelParameters.md)

### Files changed
- `README.md` — skill description
- `rules/omni-terminology.mdc` — Blobby definition
- `agents/omni-modeler.md` — modeler agent system prompt
- `skills/omni-ai-optimizer/SKILL.md` — skill description and intro
- `skills/omni-model-builder/references/modelParameters.md` — `ai_context` and `all_values` parameter descriptions

## Test plan
- [ ] Review each change to confirm the new terminology reads naturally in context
- [ ] Verify no other instances were missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)