### PR TITLE
Add validation loops to content-builder, model-builder, admin, and query skills

### DIFF
--- a/skills/omni-admin/SKILL.md
+++ b/skills/omni-admin/SKILL.md
@@ -173,6 +173,80 @@ omni schedules recipients-get <scheduleId>
 omni schedules add-recipients <scheduleId> --body '{ "recipients": [{ "type": "email", "value": "team@company.com" }] }'
 ```
 
+## Verification After Changes
+
+Admin operations can silently fail or partially apply. Always read back the state after any write to confirm the change took effect.
+
+### After User Operations
+
+```bash
+# After creating or updating a user, verify they exist with correct state
+omni scim users-list --filter 'userName eq "newuser@company.com"'
+```
+
+Check that: `active` matches what you set, `displayName` is correct, and the user ID was returned (not an error).
+
+### After Group Operations
+
+```bash
+# After creating a group or modifying members, verify membership
+omni scim groups-list
+```
+
+Check that: the group exists with the expected `displayName`, and `members` array contains the expected user UUIDs.
+
+### After Permission Changes
+
+```bash
+# After setting document permissions, verify for the target user
+omni documents get-permissions <documentId> --user-id <userId>
+
+# After setting folder permissions, verify
+omni folders get-permissions <folderId>
+```
+
+Check that: the permission `access` level matches what you set (`view`, `edit`), and the target user/group ID is listed.
+
+### After User Attribute Changes
+
+```bash
+# Verify the attribute value was set
+omni user-attributes list
+```
+
+If the attribute is used for row-level security (`access_filters`), test it by running a query as the target user:
+
+```bash
+omni query run --body '{ "query": { ... }, "userId": "<target-user-uuid>" }'
+```
+
+Verify the results are correctly filtered — the user should only see rows matching their attribute value.
+
+### After Schedule Operations
+
+```bash
+# Verify schedule was created with correct settings
+omni schedules list
+
+# Verify recipients were added
+omni schedules recipients-get <scheduleId>
+```
+
+Check that: `frequency`, `dayOfWeek`, `hour`, `timezone`, and `format` match what you set, and all intended recipients are listed.
+
+### Verification Checklist
+
+| Operation | Verify With | What to Check |
+|-----------|-------------|---------------|
+| Create/update user | `omni scim users-list --filter ...` | User exists, `active` status correct |
+| Create/update group | `omni scim groups-list` | Group exists, members list correct |
+| Set document permissions | `omni documents get-permissions` | Access level and target correct |
+| Set folder permissions | `omni folders get-permissions` | Access level and target correct |
+| Set user attribute | `omni user-attributes list` | Attribute value set |
+| User attribute + access filter | `omni query run` with `userId` | Row-level filtering works |
+| Create schedule | `omni schedules list` | Schedule settings correct |
+| Add recipients | `omni schedules recipients-get` | All recipients listed |
+
 ## Cache and Validation
 
 ```bash

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -93,98 +93,25 @@ omni documents create --body '{
 
 > **Tip**: Default to `"config": {}` for reliable rendering — Omni will auto-generate chart config. For precise chart styling, build a reference dashboard in the UI and read it back via `GET /api/v1/documents/{documentId}`. See [references/queryPresentations.md](references/queryPresentations.md) for complete config examples by chart type (KPI, line, bar, area, pie, scatter, etc.).
 
-#### Key Parameters (not fully documented elsewhere)
+#### queryPresentation Structure
 
-| Parameter | Notes |
-|-----------|-------|
-| `modelId` | Use the **base shared model UUID**, not a branchId. Get this from the List Models API. |
-| Field format | `table.field_name` or `table.field_name[week\|month\|day\|quarter\|year]` for time granularity |
-| `sorts` | `column_name` must match the **exact field string** (e.g., `"order_items.created_at[month]"`), with `sort_descending` boolean |
+See [references/queryPresentations.md](references/queryPresentations.md) for the complete reference — parameter tables for `queryPresentation` and `query` objects, `visConfig` chartType values, `config` object details, chart type examples, and caveats when reusing presentations from existing dashboards.
 
-#### queryPresentation Object Reference
+**Key points:**
+- `prefersChart` must be `true` to render a chart (otherwise always shows table)
+- `visType`: `"omni-kpi"` for KPI tiles, `"basic"` for all other charts
+- `visConfig` goes **inside** the `query` object (silently dropped if placed as sibling)
+- `fields` must be duplicated at both the `queryPresentation` and `query` levels
+- `modelId` is inherited from the document — not needed inside `query`
+- Default to `"config": {}` for reliable rendering — Omni auto-generates chart config
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `name` | Yes | Tile/tab title |
-| `topicName` | Recommended | Topic name for the query — set this whenever querying from a topic. Ensures correct join context in the dashboard. |
-| `prefersChart` | Yes | **Must be `true` to render a chart.** Without this, Omni always shows the results table regardless of any other vis settings. |
-| `visType` | Yes | Visualization renderer: `"omni-kpi"` for KPI tiles, `"basic"` for all standard charts (line, bar, area, scatter, pie, etc.). |
-| `fields` | Yes | Duplicate of `query.fields` — must be present at this level too. |
-| `config` | Yes | Chart-specific configuration object. Shape varies by chart type — read a reference dashboard to get the exact structure. |
-| `chartType` | No | Optional chart subtype at the presentation level (e.g. `"barGrouped"`). |
-| `description` | No | Tile description. |
-| `query` | Yes | Query definition (see below). |
-
-#### Query Object Reference
-
-The `query` object within each query presentation uses the same structure as the [Query API](https://docs.omni.co/api/queries.md):
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `table` | Yes | Base view name |
-| `fields` | Yes | Array of `view.field_name` references (supports timeframe brackets like `[month]`) |
-| `sorts` | No | Array of `{ "column_name": "...", "sort_descending": bool }` |
-| `filters` | No | Object of `{ "field_name": "expression" }` — supports `"last 90 days"`, `"this quarter"`, `">100"`, etc. |
-| `limit` | No | Row limit (default 1000, max 50000) |
-| `join_paths_from_topic_name` | Recommended | Topic name for join resolution — set this alongside `topicName` on the parent queryPresentation. |
-| `pivots` | No | Array of field names to pivot on |
-
-> **Note**: `modelId` is not needed inside the query object — it's inherited from the document's top-level `modelId`.
-
-#### visConfig Object
-
-`visConfig` belongs **inside the `query` object** — not at the `queryPresentation` level. When passed as a sibling of `query`, it is silently dropped by the API.
-
-`visConfig` alone does **not** control chart rendering. It stores the chart type hint on the query, but the actual rendering is driven by `prefersChart`, `visType`, and `config` at the `queryPresentation` level.
-
-**chartType values**:
-
-| chartType | Visualization |
-|-----------|--------------|
-| `kpi` | KPI / single value |
-| `lineColor` | Line chart |
-| `barColor` | Bar chart |
-| `areaColor` | Area chart |
-| `stackedBarColor` | Stacked bar chart |
-| `pie` | Pie / donut chart |
-| `scatter` | Scatter plot |
-| `heatmap` | Heatmap |
-| `map` | Map visualization |
-| `table` | Data table |
-
-#### config Object
-
-The `config` object at the `queryPresentation` level defines the actual chart rendering. Its structure varies by chart type — see [references/queryPresentations.md](references/queryPresentations.md) for complete config examples by chart type.
-
-The most reliable way to get the correct `config` for a given chart type is to **build the chart in the Omni UI and read it back** via `GET /api/v1/documents/{documentId}`.
-
-### Discovering the Full queryPresentation Structure from Existing Dashboards
-
-The most reliable way to learn `config`, `visType`, and field names is to read an existing dashboard document:
-
-**Step 1: Find a reference dashboard**
-
-```bash
-omni documents list
-```
-
-**Step 2: Get its full document**
+**To learn the exact structure for a chart type**, build a reference dashboard in the Omni UI and read it back:
 
 ```bash
 omni documents get <documentId>
 ```
 
-Returns the complete `queryPresentations` array including `topicName`, `visConfig`, `config`, and the full `query` object for each tile — use this as the source of truth when recreating or templating dashboards.
-
-> **Tip**: Build a reference dashboard in the Omni UI with the chart types and styling you want, then read it via `omni documents get <documentId>` to capture the exact `queryPresentations` structure to use as a template.
-
-#### Caveats When Reusing queryPresentations
-
-These apply when copying queryPresentations from an existing document (for both creating new dashboards and updating existing ones):
-
-- **Strip `model_extension_id`** from each query object — these reference model extensions scoped to the source document and will cause "Chart unavailable" errors.
-- **Filter to the tiles you want** — `omni documents get` returns all queries including workbook-only tabs not shown on the dashboard. Only include the `queryPresentations` you want as visible tiles.
-- **Queries without `topicName` are valid** — SQL-mode and tab-selector queries won't have a `topicName`. Do not add one.
+**When reusing queryPresentations from existing documents**, always strip `model_extension_id` from query objects (causes "Chart unavailable" errors) and filter to only the tiles you want.
 
 ### Rename Document
 

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -11,7 +11,7 @@ Create, update, and manage Omni documents and dashboards programmatically via th
 
 ## Known Issues & Safe Defaults
 
-- **Always test queries before creating a dashboard** — run each planned query via `omni query run` first, including the filters you intend to use. This catches bad field names, missing joins, and malformed filter expressions before they become broken tiles.
+- **Always run the full validation loop** — see [Validation Loops](#validation-loops) below. At minimum: validate the model, test every query via `omni query run`, check viz spec consistency, and verify the dashboard after creation by reading it back and executing its queries.
 - **Chart rendering**: Complex chart types may show "No chart available" in the Omni UI if `config`, `visType`, or `prefersChart` are misconfigured. Default to `chartType: "table"` for reliable rendering, and configure chart visualizations in the Omni UI.
 - **Every query must include at least one measure** — a query with only dimensions produces empty/nonsense tiles (e.g., just months with no data).
 - **Use `identifier` not `id`** for all document API calls — `.id` is null for workbook-type documents and will silently fail.
@@ -402,23 +402,142 @@ Workbook:  {OMNI_BASE_URL}/w/{identifier}
 
 The `identifier` comes from the document's `identifier` field in API responses (not `id`, which is null for workbooks).
 
+## Validation Loops
+
+Every dashboard build or update must include validation before and after creation. Broken tiles, bad field references, and misconfigured viz specs are silent failures — the dashboard renders but tiles show "Chart unavailable" or "No data" with no API-level error.
+
+### Step 1: Validate the Model
+
+Before building any queries, confirm the underlying model is healthy:
+
+```bash
+omni models validate <modelId>
+```
+
+Check the response for errors (not just warnings). If `is_warning` is `false` on any issue, the field or join may be broken and queries referencing it will fail silently on the dashboard.
+
+### Step 2: Test Every Query via Execution
+
+Run each planned query through `omni query run` **before** including it in a dashboard. This is the single most important validation step.
+
+```bash
+omni query run --body '{
+  "query": {
+    "modelId": "your-model-id",
+    "table": "order_items",
+    "fields": ["order_items.created_at[month]", "order_items.total_revenue"],
+    "filters": { "order_items.created_at": "last 90 days" },
+    "limit": 10,
+    "join_paths_from_topic_name": "order_items"
+  }
+}'
+```
+
+**What to check in the response:**
+- **No error field** — if the response contains an `error` key, the query is broken. Fix before proceeding.
+- **`summary.row_count` > 0** — a query that returns zero rows will render as an empty tile. This may be correct (no data for the filter range) but is worth flagging.
+- **Include your dashboard filters** — pass the same filters you plan to use in `filterConfig` as query-level filters here. This catches bad filter expressions (e.g., wrong field name, unsupported syntax) before they become dashboard-level problems.
+- **Long-running queries** — if the response includes `remaining_job_ids`, poll with `omni query wait --job-ids <ids>` until complete, then check the final result for errors.
+
+Do this for **every** query you plan to include as a tile. A dashboard with 5 tiles needs 5 validated queries.
+
+### Step 3: Validate Viz Spec Consistency
+
+Before assembling `queryPresentations`, check each tile's viz configuration against these rules. Mismatches cause "No chart available" or silent fallback to table rendering.
+
+**Required consistency checks:**
+
+| Rule | What to check |
+|------|---------------|
+| `prefersChart` must be `true` for charts | If `false` or omitted, Omni renders a table regardless of other viz settings |
+| `visType` must match chart category | `"omni-kpi"` for KPI tiles, `"basic"` for all other chart types (line, bar, area, scatter, pie, table) |
+| `visConfig.chartType` must be valid | Must be one of: `table`, `kpi`, `lineColor`, `barColor`, `areaColor`, `stackedBarColor`, `pie`, `scatter`, `heatmap`, `map` |
+| `config` fields must match chart type | Cartesian charts (line, bar, area, scatter) require `mark`, `series`, `tooltip`, `version`, `behaviors`, `configType: "cartesian"`, `_dependentAxis` |
+| `_dependentAxis` must match orientation | `"y"` for vertical charts (line, vertical bar, area, scatter), `"x"` for horizontal bar charts |
+| `mark.type` must match `visConfig.chartType` | `lineColor` → `"line"`, `barColor`/`stackedBarColor` → `"bar"`, `areaColor` → `"area"`, `scatter` → `"point"` |
+| `series[].yAxis` or `series[].xAxis` | Must use `yAxis: "y"` for vertical charts, `xAxis: "x"` for horizontal bars |
+| KPI tiles need `markdownConfig` | `config.markdownConfig` array with at least one entry referencing a field from the query |
+| `fields` must be duplicated | The `fields` array must appear at both the `queryPresentation` level AND inside the `query` object |
+| Every query must have a measure | Queries with only dimensions produce empty/broken tiles |
+
+> **Tip**: When unsure about a viz config, default to `"prefersChart": false` with `"config": {}` to render as a table. Tables always work. Configure charts in the Omni UI afterward.
+
+### Step 4: Post-Creation Verification
+
+After creating or updating a dashboard, always read it back and verify the tiles work:
+
+**4a. Read back the document:**
+
+```bash
+omni documents get <documentIdentifier>
+```
+
+Check that:
+- The response includes all expected `queryPresentations` (count matches what you sent)
+- No `queryPresentations` entries have null or missing `query` objects
+- The `identifier` is present (you'll need it for the share link)
+
+**4b. Execute the dashboard's queries to verify they run:**
+
+```bash
+# Extract the queries powering the dashboard tiles
+omni documents get-queries <documentIdentifier>
+```
+
+This returns the query objects for each tile. Run each one to confirm they execute without errors:
+
+```bash
+# For each query returned, execute it
+omni query run --body '{
+  "query": <query-object-from-get-queries>,
+  "resultType": "csv"
+}'
+```
+
+Using `"resultType": "csv"` makes it easy to spot-check that the data looks reasonable (correct columns, non-empty rows, expected value ranges).
+
+**What to check:**
+- Every tile's query executes without error
+- `summary.row_count` > 0 for tiles that should show data
+- No unexpected `remaining_job_ids` (which might indicate query timeout issues)
+
+**4c. If any query fails:** The dashboard has a broken tile. Either update the document to fix the query (via `PUT /api/v1/documents/{documentId}`) or flag the issue to the user before sharing the link.
+
+### Validation Checklist Summary
+
+| Phase | Check | Tool |
+|-------|-------|------|
+| Pre-build | Model has no errors | `omni models validate <modelId>` |
+| Pre-build | Each query executes successfully | `omni query run` per query |
+| Pre-build | Each query returns rows | Check `summary.row_count` |
+| Pre-build | Filters parse correctly | Include filters in `omni query run` |
+| Pre-build | Viz specs are internally consistent | Manual check against rules above |
+| Post-build | Document has all expected tiles | `omni documents get` and count `queryPresentations` |
+| Post-build | All tile queries execute on the dashboard | `omni documents get-queries` + `omni query run` each |
+| Post-build | Data looks correct | Spot-check CSV output for reasonableness |
+
 ## Recommended Build Workflows
 
 ### API-First (Full Programmatic Creation)
 
 1. **Discover fields** — use `omni-model-explorer` to find topic + fields
-2. **Test each query** — run every query you plan to include via `omni query run` (using `omni-query`) before building the dashboard. Include the same filters you plan to use in `filterConfig` as query-level filters to confirm they parse correctly. This catches field name typos, missing join paths, bad filter expressions, and permission errors before they become broken tiles.
-3. **Create document** — single `omni documents create` with `queryPresentations` + `filterConfig` + `filterOrder` all in one call
-4. **Share the link** — return `{OMNI_BASE_URL}/dashboards/{identifier}` to the user
-5. **Refine in UI** — tile layout, chart styling, and advanced config are best done in the Omni UI
+2. **Validate model** — run `omni models validate <modelId>` and check for errors
+3. **Test each query** — run every query you plan to include via `omni query run` (using `omni-query`) before building the dashboard. Include the same filters you plan to use in `filterConfig` as query-level filters to confirm they parse correctly. This catches field name typos, missing join paths, bad filter expressions, and permission errors before they become broken tiles.
+4. **Validate viz specs** — check each tile's `visType`/`chartType`/`config`/`prefersChart` against the [consistency rules](#step-3-validate-viz-spec-consistency) before assembling the payload
+5. **Create document** — single `omni documents create` with `queryPresentations` + `filterConfig` + `filterOrder` all in one call
+6. **Verify the dashboard** — read it back with `omni documents get`, confirm all tiles are present, then run each tile's query via `omni documents get-queries` + `omni query run` to verify no broken tiles
+7. **Share the link** — return `{OMNI_BASE_URL}/dashboards/{identifier}` to the user (only after verification passes)
+8. **Refine in UI** — tile layout, chart styling, and advanced config are best done in the Omni UI
 
 ### Update Existing Dashboard
 
 1. **Find the dashboard** — use `omni-content-explorer` or `omni documents list` to locate it
 2. **Read its current state** — `omni documents get <documentId>` to get the full document including `queryPresentations`, `filterConfig`, etc.
 3. **Modify** — add, remove, or edit entries in the `queryPresentations` array; update `filterConfig`/`filterOrder` as needed
-4. **PUT the update** — `PUT /api/v1/documents/{documentId}` with the complete modified document and `clearExistingDraft: true`
-5. **Share the link** — return `{OMNI_BASE_URL}/dashboards/{identifier}` to the user
+4. **Validate changes** — run any new or modified queries via `omni query run` to confirm they work. Check modified viz specs against the [consistency rules](#step-3-validate-viz-spec-consistency).
+5. **PUT the update** — `PUT /api/v1/documents/{documentId}` with the complete modified document and `clearExistingDraft: true`
+6. **Verify the update** — read the document back with `omni documents get` and confirm the expected tiles are present. Run `omni documents get-queries` + `omni query run` on modified tiles to verify they execute without error.
+7. **Share the link** — return `{OMNI_BASE_URL}/dashboards/{identifier}` to the user (only after verification passes)
 
 ### UI-First (Hybrid Approach)
 

--- a/skills/omni-content-builder/references/queryPresentations.md
+++ b/skills/omni-content-builder/references/queryPresentations.md
@@ -1,8 +1,99 @@
 # queryPresentations Reference
 
-Complete config examples for each chart type. Use these as templates when creating documents with `queryPresentations`.
+Complete reference for queryPresentation objects — parameter tables, visConfig/config details, chart type examples, and caveats for reusing presentations from existing dashboards.
 
 Every `queryPresentation` object requires: `name`, `prefersChart: true`, `visType`, `fields`, `query`, and `config`. The `config` shape varies by chart type — the examples below show the exact structure for each.
+
+## Key Parameters
+
+| Parameter | Notes |
+|-----------|-------|
+| `modelId` | Use the **base shared model UUID**, not a branchId. Get this from the List Models API. |
+| Field format | `table.field_name` or `table.field_name[week\|month\|day\|quarter\|year]` for time granularity |
+| `sorts` | `column_name` must match the **exact field string** (e.g., `"order_items.created_at[month]"`), with `sort_descending` boolean |
+
+## queryPresentation Object Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `name` | Yes | Tile/tab title |
+| `topicName` | Recommended | Topic name for the query — set this whenever querying from a topic. Ensures correct join context in the dashboard. |
+| `prefersChart` | Yes | **Must be `true` to render a chart.** Without this, Omni always shows the results table regardless of any other vis settings. |
+| `visType` | Yes | Visualization renderer: `"omni-kpi"` for KPI tiles, `"basic"` for all standard charts (line, bar, area, scatter, pie, etc.). |
+| `fields` | Yes | Duplicate of `query.fields` — must be present at this level too. |
+| `config` | Yes | Chart-specific configuration object. Shape varies by chart type — see chart examples below. |
+| `chartType` | No | Optional chart subtype at the presentation level (e.g. `"barGrouped"`). |
+| `description` | No | Tile description. |
+| `query` | Yes | Query definition (see below). |
+
+## Query Object Parameters
+
+The `query` object within each query presentation uses the same structure as the [Query API](https://docs.omni.co/api/queries.md):
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `table` | Yes | Base view name |
+| `fields` | Yes | Array of `view.field_name` references (supports timeframe brackets like `[month]`) |
+| `sorts` | No | Array of `{ "column_name": "...", "sort_descending": bool }` |
+| `filters` | No | Object of `{ "field_name": "expression" }` — supports `"last 90 days"`, `"this quarter"`, `">100"`, etc. |
+| `limit` | No | Row limit (default 1000, max 50000) |
+| `join_paths_from_topic_name` | Recommended | Topic name for join resolution — set this alongside `topicName` on the parent queryPresentation. |
+| `pivots` | No | Array of field names to pivot on |
+
+> **Note**: `modelId` is not needed inside the query object — it's inherited from the document's top-level `modelId`.
+
+## visConfig Object
+
+`visConfig` belongs **inside the `query` object** — not at the `queryPresentation` level. When passed as a sibling of `query`, it is silently dropped by the API.
+
+`visConfig` alone does **not** control chart rendering. It stores the chart type hint on the query, but the actual rendering is driven by `prefersChart`, `visType`, and `config` at the `queryPresentation` level.
+
+**chartType values**:
+
+| chartType | Visualization |
+|-----------|--------------|
+| `kpi` | KPI / single value |
+| `lineColor` | Line chart |
+| `barColor` | Bar chart |
+| `areaColor` | Area chart |
+| `stackedBarColor` | Stacked bar chart |
+| `pie` | Pie / donut chart |
+| `scatter` | Scatter plot |
+| `heatmap` | Heatmap |
+| `map` | Map visualization |
+| `table` | Data table |
+
+## config Object
+
+The `config` object at the `queryPresentation` level defines the actual chart rendering. Its structure varies by chart type — see the chart examples below.
+
+The most reliable way to get the correct `config` for a given chart type is to **build the chart in the Omni UI and read it back** via `GET /api/v1/documents/{documentId}`.
+
+## Discovering the Full Structure from Existing Dashboards
+
+The most reliable way to learn `config`, `visType`, and field names is to read an existing dashboard:
+
+```bash
+# Step 1: Find a reference dashboard
+omni documents list
+
+# Step 2: Get its full document
+omni documents get <documentId>
+```
+
+Returns the complete `queryPresentations` array including `topicName`, `visConfig`, `config`, and the full `query` object for each tile — use this as the source of truth when recreating or templating dashboards.
+
+> **Tip**: Build a reference dashboard in the Omni UI with the chart types and styling you want, then read it via `omni documents get <documentId>` to capture the exact `queryPresentations` structure to use as a template.
+
+## Caveats When Reusing queryPresentations
+
+These apply when copying queryPresentations from an existing document (for both creating new dashboards and updating existing ones):
+
+- **Strip `model_extension_id`** from each query object — these reference model extensions scoped to the source document and will cause "Chart unavailable" errors.
+- **Filter to the tiles you want** — `omni documents get` returns all queries including workbook-only tabs not shown on the dashboard. Only include the `queryPresentations` you want as visible tiles.
+- **Queries without `topicName` are valid** — SQL-mode and tab-selector queries won't have a `topicName`. Do not add one.
+
+## Chart Type Examples
 
 ## Table (Safe Default)
 

--- a/skills/omni-content-builder/references/queryPresentations.md
+++ b/skills/omni-content-builder/references/queryPresentations.md
@@ -95,7 +95,7 @@ These apply when copying queryPresentations from an existing document (for both 
 
 ## Chart Type Examples
 
-## Table (Safe Default)
+### Table (Safe Default)
 
 The simplest and most reliable visualization. Use when unsure about chart config.
 
@@ -123,7 +123,7 @@ Key differences from chart types:
 - `config` is an empty object `{}`
 - `visConfig.chartType` is `"table"`
 
-## KPI (Single Value)
+### KPI (Single Value)
 
 Displays one or more big numbers. Uses `visType: "omni-kpi"` (not `"basic"`).
 
@@ -209,7 +209,7 @@ Add more entries to `markdownConfig`. Each entry gets a unique `id`:
 | `markdownConfig[].config.field.label.value` | Yes | Display label for the KPI |
 | `markdownConfig[].config.descriptionBefore` | No | Text shown above the number |
 
-## Line Chart
+### Line Chart
 
 Time-series or continuous data. Uses `visType: "basic"` with cartesian config.
 
@@ -264,7 +264,7 @@ Add more entries to `series`, and include them in `tooltip`:
 ]
 ```
 
-## Bar Chart (Horizontal)
+### Bar Chart (Horizontal)
 
 Dimension on y-axis, measure on x-axis. Good for ranked lists (Top N).
 
@@ -303,7 +303,7 @@ Dimension on y-axis, measure on x-axis. Good for ranked lists (Top N).
 }
 ```
 
-## Bar Chart (Vertical)
+### Bar Chart (Vertical)
 
 Dimension on x-axis, measure on y-axis. The axes and `_dependentAxis` flip compared to horizontal.
 
@@ -342,7 +342,7 @@ Dimension on x-axis, measure on y-axis. The axes and `_dependentAxis` flip compa
 }
 ```
 
-## Area Chart
+### Area Chart
 
 Same structure as line chart but with `mark.type: "area"` and `visConfig.chartType: "areaColor"`.
 
@@ -380,7 +380,7 @@ Same structure as line chart but with `mark.type: "area"` and `visConfig.chartTy
 }
 ```
 
-## Stacked Bar Chart
+### Stacked Bar Chart
 
 Uses `"_stack": "stack"` instead of `"_stack": "group"` in `color`, and `visConfig.chartType: "stackedBarColor"`.
 

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -122,23 +122,84 @@ omni models yaml-create <modelId> --body '{
 
 > **Note**: The `branchId` parameter must be a UUID from the server (Step 0). Passing a string name instead will return `400 Bad Request: Unrecognized key: "branchName"`.
 
-### Step 2: Validate
+### Step 2: Validate and Test
+
+Every YAML write must be validated and tested before merging. Silent failures are common — a field can be syntactically valid YAML but produce wrong results or broken queries.
+
+**2a. Run model validation:**
 
 ```bash
 omni models validate <modelId> --branch-id <branchId>
 ```
 
-Returns validation errors and warnings with `message`, `yaml_path`, and sometimes `auto_fix`.
+Check the response:
+- If any issue has `is_warning: false`, it's an error — fix before proceeding
+- Common errors: broken column references, duplicate field names, invalid SQL syntax, missing join paths
+- If `auto_fix` is present, review the suggestion before applying
+
+**2b. Test new/modified fields with a query:**
+
+Run a query that exercises the fields you just created or modified:
+
+```bash
+omni query run --body '{
+  "query": {
+    "modelId": "<modelId>",
+    "branchId": "<branchId>",
+    "table": "your_view",
+    "fields": ["your_view.new_dimension", "your_view.new_measure"],
+    "limit": 10,
+    "join_paths_from_topic_name": "your_topic"
+  }
+}'
+```
+
+**What to check:**
+- **No error in response** — if the query returns an error, the field SQL is broken (bad column reference, wrong aggregate, dialect mismatch)
+- **`summary.row_count` > 0** — confirms the field resolves to actual data
+- **Values look correct** — spot-check that a `sum` isn't returning a `count`, that a boolean dimension returns true/false (not 0/1 unexpectedly), etc.
+- **Joins work** — if your field references another view (e.g., `${users.id}`), include fields from both views to confirm the join resolves
+
+**2c. If you modified a relationship or topic join, test the join path:**
+
+```bash
+omni query run --body '{
+  "query": {
+    "modelId": "<modelId>",
+    "branchId": "<branchId>",
+    "table": "base_view",
+    "fields": ["base_view.id", "joined_view.some_field"],
+    "limit": 10,
+    "join_paths_from_topic_name": "your_topic"
+  }
+}'
+```
+
+A working join returns rows with data from both views. A broken join returns an error or null values in the joined columns.
+
+**2d. Verify the field appears in the model:**
+
+```bash
+omni models get <modelId> --branch-id <branchId>
+```
+
+Confirm your new fields are listed in the model response. If they're missing, the YAML write may have silently failed (e.g., wrong `fileName`, malformed YAML string).
 
 ### Step 3: Merge the Branch
 
-> **Important**: Always ask the user for confirmation before merging. Merging applies changes to the production model and cannot be easily undone.
+> **Important**: Always ask the user for confirmation before merging. Merging applies changes to the production model and cannot be easily undone. Only merge after validation and testing pass (Step 2).
 
 ```bash
 omni models merge-branch <modelId> <branchName>
 ```
 
 If git with required PRs is configured, merge through your git workflow instead.
+
+After merging, run one final validation against the production model to confirm the merge didn't introduce conflicts:
+
+```bash
+omni models validate <modelId>
+```
 
 ## YAML File Types
 

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -139,23 +139,21 @@ Check the response:
 
 **2b. Test new/modified fields with a query:**
 
-Run a query that exercises the fields you just created or modified:
+Run a query that exercises the fields you just created or modified. Use `omni ai generate-query` with `branchId` to test against the branch (the standard `omni query run` endpoint does not support `branchId`):
 
 ```bash
-omni query run --body '{
-  "query": {
-    "modelId": "<modelId>",
-    "branchId": "<branchId>",
-    "table": "your_view",
-    "fields": ["your_view.new_dimension", "your_view.new_measure"],
-    "limit": 10,
-    "join_paths_from_topic_name": "your_topic"
-  }
+omni ai generate-query --body '{
+  "modelId": "<modelId>",
+  "branchId": "<branchId>",
+  "prompt": "Show me your_view.new_dimension and your_view.new_measure limit 10",
+  "runQuery": true
 }'
 ```
 
+Alternatively, if you want full control over the query structure, merge the branch first and test with `omni query run` against the production model — but this is riskier since you can't undo a merge easily.
+
 **What to check:**
-- **No error in response** — if the query returns an error, the field SQL is broken (bad column reference, wrong aggregate, dialect mismatch)
+- **No `error` in response** — if the query returns an error, the field SQL is broken (bad column reference, wrong aggregate, dialect mismatch)
 - **`summary.row_count` > 0** — confirms the field resolves to actual data
 - **Values look correct** — spot-check that a `sum` isn't returning a `count`, that a boolean dimension returns true/false (not 0/1 unexpectedly), etc.
 - **Joins work** — if your field references another view (e.g., `${users.id}`), include fields from both views to confirm the join resolves
@@ -163,15 +161,11 @@ omni query run --body '{
 **2c. If you modified a relationship or topic join, test the join path:**
 
 ```bash
-omni query run --body '{
-  "query": {
-    "modelId": "<modelId>",
-    "branchId": "<branchId>",
-    "table": "base_view",
-    "fields": ["base_view.id", "joined_view.some_field"],
-    "limit": 10,
-    "join_paths_from_topic_name": "your_topic"
-  }
+omni ai generate-query --body '{
+  "modelId": "<modelId>",
+  "branchId": "<branchId>",
+  "prompt": "Show base_view.id and joined_view.some_field limit 10",
+  "runQuery": true
 }'
 ```
 
@@ -180,10 +174,14 @@ A working join returns rows with data from both views. A broken join returns an 
 **2d. Verify the field appears in the model:**
 
 ```bash
-omni models get <modelId> --branch-id <branchId>
+# Check the topic to confirm new fields are listed
+omni models get-topic <modelId> <topicName> --branch-id <branchId>
+
+# Or read back the YAML you just wrote
+omni models yaml-get <modelId> --file-name your_view.view --branch-id <branchId>
 ```
 
-Confirm your new fields are listed in the model response. If they're missing, the YAML write may have silently failed (e.g., wrong `fileName`, malformed YAML string).
+Confirm your new fields are listed in the response. If they're missing, the YAML write may have silently failed (e.g., wrong `fileName`, malformed YAML string).
 
 ### Step 3: Merge the Branch
 

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -139,21 +139,24 @@ Check the response:
 
 **2b. Test new/modified fields with a query:**
 
-Run a query that exercises the fields you just created or modified. Use `omni ai generate-query` with `branchId` to test against the branch (the standard `omni query run` endpoint does not support `branchId`):
+Run a query that exercises the fields you just created or modified:
+
+> **Note**: `omni query run` does not currently support `branchId` — queries always run against the production model. This means you can only fully test new fields after merging. Use model validation (2a) and field verification (2d) as your pre-merge safety net, and run query tests immediately after merging.
 
 ```bash
-omni ai generate-query --body '{
-  "modelId": "<modelId>",
-  "branchId": "<branchId>",
-  "prompt": "Show me your_view.new_dimension and your_view.new_measure limit 10",
-  "runQuery": true
+omni query run --body '{
+  "query": {
+    "modelId": "<modelId>",
+    "table": "your_view",
+    "fields": ["your_view.new_dimension", "your_view.new_measure"],
+    "limit": 10,
+    "join_paths_from_topic_name": "your_topic"
+  }
 }'
 ```
 
-Alternatively, if you want full control over the query structure, merge the branch first and test with `omni query run` against the production model — but this is riskier since you can't undo a merge easily.
-
 **What to check:**
-- **No `error` in response** — if the query returns an error, the field SQL is broken (bad column reference, wrong aggregate, dialect mismatch)
+- **No error in response** — if the query returns an error, the field SQL is broken (bad column reference, wrong aggregate, dialect mismatch)
 - **`summary.row_count` > 0** — confirms the field resolves to actual data
 - **Values look correct** — spot-check that a `sum` isn't returning a `count`, that a boolean dimension returns true/false (not 0/1 unexpectedly), etc.
 - **Joins work** — if your field references another view (e.g., `${users.id}`), include fields from both views to confirm the join resolves
@@ -161,11 +164,14 @@ Alternatively, if you want full control over the query structure, merge the bran
 **2c. If you modified a relationship or topic join, test the join path:**
 
 ```bash
-omni ai generate-query --body '{
-  "modelId": "<modelId>",
-  "branchId": "<branchId>",
-  "prompt": "Show base_view.id and joined_view.some_field limit 10",
-  "runQuery": true
+omni query run --body '{
+  "query": {
+    "modelId": "<modelId>",
+    "table": "base_view",
+    "fields": ["base_view.id", "joined_view.some_field"],
+    "limit": 10,
+    "join_paths_from_topic_name": "your_topic"
+  }
 }'
 ```
 

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -106,7 +106,7 @@ Expressions: `"last 90 days"`, `"this quarter"`, `"2024-01-01 to 2024-12-31"`, `
 }
 ```
 
-## Handling Results
+## Handling and Validating Results
 
 Default response: base64-encoded Apache Arrow table. Arrow results are binary — you cannot parse individual row data from the raw response. To verify a query returned data, check `summary.row_count` in the response.
 
@@ -115,6 +115,59 @@ For human-readable results, request CSV instead:
 ```json
 { "query": { ... }, "resultType": "csv" }
 ```
+
+### Result Validation
+
+Every query response should be checked before trusting the results or presenting them to the user.
+
+**Check for errors:**
+- If the response contains an `error` key, the query failed. Common causes: bad field name, missing join path, malformed filter expression, permission error.
+- If the response contains `remaining_job_ids`, the query is still running — poll with `omni query wait` before checking results.
+
+**Check row count:**
+- `summary.row_count == 0` — the query returned no data. This may be valid (e.g., no data in the filter range) but is worth flagging to the user. Common causes: overly restrictive filters, wrong date range, field that doesn't match any rows.
+- `summary.row_count` equals the `limit` you set — results may be truncated. If the user needs complete data, re-run with a higher limit or `null` for unlimited.
+
+**Spot-check data with CSV:**
+
+When accuracy matters, request CSV and scan the output:
+
+```bash
+omni query run --body '{
+  "query": { ... },
+  "resultType": "csv"
+}'
+```
+
+Check that:
+- Column headers match the fields you requested
+- Values are in expected ranges (e.g., revenue isn't negative, dates aren't in the future)
+- Aggregations make sense (e.g., a count isn't returning a sum)
+
+**Validate filter behavior:**
+
+If your query includes filters, verify they're being applied:
+
+```bash
+# Run the same query without filters
+omni query run --body '{ "query": { ... (no filters) ... }, "resultType": "csv" }'
+
+# Compare row counts — filtered should be <= unfiltered
+```
+
+If both queries return the same row count, the filter may not be binding (wrong field name, unsupported expression, or the known bug where boolean filters are dropped with pivots).
+
+### Validation Checklist
+
+| Check | How | When |
+|-------|-----|------|
+| No error in response | Check for `error` key | Every query |
+| Data was returned | `summary.row_count > 0` | Every query |
+| Results not truncated | `row_count < limit` | When completeness matters |
+| Columns are correct | CSV column headers match requested fields | When building dashboards or reports |
+| Values are reasonable | Spot-check CSV output | When presenting to users |
+| Filters are applied | Compare filtered vs unfiltered row counts | When using filters |
+| Long-running query completed | No `remaining_job_ids` in final response | Queries on large tables |
 
 ### Decoding Arrow Results
 


### PR DESCRIPTION
## Summary
- **content-builder**: New "Validation Loops" section with 4-step pre/post-creation workflow — model validation, query execution testing, viz spec consistency checks, and post-creation read-back verification with tile query execution
- **model-builder**: Expanded Step 2 (validate) into a 4-part loop — model validation, query testing of new fields, join path verification, field existence check, plus post-merge validation
- **admin**: New "Verification After Changes" section with read-back patterns for users, groups, permissions, user attributes (including access filter testing), and schedules
- **query**: New "Result Validation" section with error detection, row count checks, truncation warnings, filter binding validation, and CSV spot-checking guidance

Each skill now includes a summary checklist table for quick reference.

## Test plan
- [x] Review each skill's validation section for accuracy against Omni API behavior
- [x] Confirm CLI commands in examples are valid (`omni models validate`, `omni query run`, `omni documents get-queries`, etc.)
- [x] Test content-builder workflow end-to-end: build a dashboard using the new validation loop steps
- [x] Test model-builder workflow: write YAML to a branch, run the full Step 2 validation, merge
- [x] Test admin workflow: create a user, set permissions, verify read-back works as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)