### PR TITLE
Update skills for CLI shorthand syntax (exploreomni/cli#26)

### DIFF
--- a/rules/omni-api-conventions.mdc
+++ b/rules/omni-api-conventions.mdc
@@ -53,9 +53,9 @@ omni <group> <operation> [positional-args] [--flags] [--body 'JSON']
 
 - **Group**: the API resource (e.g., `models`, `documents`, `scim`, `query`)
 - **Operation**: the action (e.g., `list`, `create`, `yaml-get`)
-- **Positional args**: path parameters like `<modelId>`, `<identifier>`
-- **Flags**: query parameters as `--flag-name value`
-- **Body**: request body as `--body '{"key": "value"}'` or `--body -` to read from stdin
+- **Positional args**: path parameters like `<modelId>`, `<identifier>`, plus shorthand body args (e.g., `omni ai generate-query <model-id> "prompt"`)
+- **Flags**: query parameters and promoted body fields as `--flag-name value`
+- **Body**: request body as `--body '{"key": "value"}'` or `--body -` to read from stdin (still supported, but prefer shorthand args/flags when available)
 
 ### Discovering Commands
 

--- a/skills/omni-ai-eval/SKILL.md
+++ b/skills/omni-ai-eval/SKILL.md
@@ -51,16 +51,12 @@ Each eval case pairs a natural language prompt with the expected query structure
 
 ## Running Evals: Fast Path (Generate Query API)
 
-The synchronous generate-query endpoint is the fastest way to eval query generation. Set `runQuery: false` to get only the generated query JSON without executing it against the database.
+The synchronous generate-query endpoint is the fastest way to eval query generation. Pass `--run-query false` to get only the generated query JSON without executing it against the database.
 
 ### Single Eval Call
 
 ```bash
-omni ai generate-query --body '{
-  "modelId": "your-model-id",
-  "prompt": "Show me revenue by month",
-  "runQuery": false
-}'
+omni ai generate-query your-model-id "Show me revenue by month" --run-query false
 ```
 
 ### Response Structure
@@ -81,13 +77,13 @@ omni ai generate-query --body '{
 
 ### Request Parameters
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `modelId` | Yes | UUID of the Omni model |
-| `prompt` | Yes | Natural language question |
-| `runQuery` | No | Set `false` to skip query execution (faster, default `true`) |
-| `branchId` | No | Branch UUID for branch-specific testing |
-| `currentTopicName` | No | Constrain topic selection to a specific topic |
+| Arg/Flag | Required | Description |
+|----------|----------|-------------|
+| `<model-id>` | Yes | UUID of the Omni model (positional arg) |
+| `<prompt>` | Yes | Natural language question (positional arg) |
+| `--run-query` | No | Set `false` to skip query execution (faster, default `true`) |
+| `--branch-id` | No | Branch UUID for branch-specific testing |
+| `--current-topic-name` | No | Constrain topic selection to a specific topic |
 
 ### Batch Loop (bash)
 
@@ -98,13 +94,12 @@ while IFS= read -r line; do
   model_id=$(echo "$line" | jq -r '.modelId')
   branch_id=$(echo "$line" | jq -r '.branchId // empty')
 
-  body=$(jq -n \
-    --arg p "$prompt" \
-    --arg m "$model_id" \
-    --arg b "$branch_id" \
-    '{modelId: $m, prompt: $p, runQuery: false} + (if $b != "" then {branchId: $b} else {} end)')
+  branch_flag=""
+  if [ -n "$branch_id" ]; then
+    branch_flag="--branch-id $branch_id"
+  fi
 
-  result=$(omni ai generate-query --body "$body" --compact)
+  result=$(omni ai generate-query "$model_id" "$prompt" --run-query false $branch_flag --compact)
 
   echo "{\"id\": \"$id\", \"generated\": $result}" >> eval_results.jsonl
 done < eval_cases.jsonl
@@ -117,10 +112,7 @@ Use the async AI Jobs API when you want to test the full agentic workflow — mu
 ### Submit a Job
 
 ```bash
-omni ai job-submit --body '{
-  "modelId": "your-model-id",
-  "prompt": "Show me revenue by month"
-}'
+omni ai job-submit your-model-id "Show me revenue by month"
 ```
 
 Response:
@@ -183,10 +175,7 @@ The result contains an `actions` array. Look for actions with `type: "generate_q
 Eval topic selection independently with the pick-topic endpoint:
 
 ```bash
-omni ai pick-topic --body '{
-  "modelId": "your-model-id",
-  "prompt": "How many users signed up last month?"
-}'
+omni ai pick-topic your-model-id "How many users signed up last month?"
 ```
 
 Response:
@@ -266,8 +255,8 @@ Run the same eval suite with one variable changed to measure impact. This is the
 
 ### Common Variables to Compare
 
-- **Model branches** — pass different `branchId` values to test context changes on a branch before merging
-- **Topic scope** — `currentTopicName: "orders"` vs omitted (auto-select)
+- **Model branches** — pass different `--branch-id` values to test context changes on a branch before merging
+- **Topic scope** — `--current-topic-name "orders"` vs omitted (auto-select)
 - **Model context changes** — `ai_context`, `sample_queries`, field descriptions (apply via `omni-model-builder` on a branch, then eval against that branch)
 - **Prompt wording** — same expected query, different prompt text
 - **AI configuration** — model type, thinking level, or other AI parameters

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -116,13 +116,10 @@ omni documents get <documentId>
 ### Rename Document
 
 ```bash
-omni documents update <documentId> --body '{
-  "name": "Q1 Revenue Report (Updated)",
-  "clearExistingDraft": true
-}'
+omni documents update <documentId> --name "Q1 Revenue Report (Updated)" --clear-existing-draft
 ```
 
-Set `clearExistingDraft: true` if the document has an existing draft, otherwise the API returns 409 Conflict.
+Pass `--clear-existing-draft` if the document has an existing draft, otherwise the API returns 409 Conflict.
 
 ### Delete Document
 
@@ -135,21 +132,15 @@ Soft-deletes the document (moves to Trash).
 ### Move Document
 
 ```bash
-omni documents move <documentId> --body '{
-  "folderPath": "/Marketing/Reports",
-  "scope": "organization"
-}'
+omni documents move <documentId> "/Marketing/Reports" --scope organization
 ```
 
-Use `"folderPath": null` to move to root. `scope` is optional — auto-computed from the destination folder.
+Use `"null"` as the folder path to move to root. `--scope` is optional — auto-computed from the destination folder.
 
 ### Duplicate Document
 
 ```bash
-omni documents duplicate <documentId> --body '{
-  "name": "Copy of Q1 Revenue Report",
-  "folderPath": "/Marketing/Reports"
-}'
+omni documents duplicate <documentId> "Copy of Q1 Revenue Report" --folder-path "/Marketing/Reports"
 ```
 
 Only published documents can be duplicated. Draft documents return 404.

--- a/skills/omni-content-explorer/SKILL.md
+++ b/skills/omni-content-explorer/SKILL.md
@@ -95,7 +95,7 @@ Useful for understanding what a dashboard computes and re-running queries via `o
 omni folders list
 
 # Create
-omni folders create --body '{ "name": "Q1 Reports", "scope": "organization" }'
+omni folders create "Q1 Reports" --scope organization
 ```
 
 ## Labels

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -207,15 +207,11 @@ Instead of constructing query JSON manually, you can describe what you want in n
 
 ### Generate Query (synchronous)
 
-The fastest path — returns a generated query JSON synchronously. Set `runQuery: false` to get only the query structure without executing it, or `true` (default) to also run it against the database.
+The fastest path — returns a generated query JSON synchronously. Pass `--run-query false` to get only the query structure without executing it (default runs the query).
 
 ```bash
 # Just generate the query JSON (no execution)
-omni ai generate-query --body '{
-  "modelId": "your-model-id",
-  "prompt": "Show me revenue by month",
-  "runQuery": false
-}'
+omni ai generate-query your-model-id "Show me revenue by month" --run-query false
 ```
 
 Response:
@@ -236,25 +232,19 @@ Response:
 
 ```bash
 # Generate and execute in one call
-omni ai generate-query --body '{
-  "modelId": "your-model-id",
-  "prompt": "Top 10 customers by lifetime spend"
-}'
+omni ai generate-query your-model-id "Top 10 customers by lifetime spend"
 ```
 
-Optional parameters:
-- `branchId` — test against a specific model branch
-- `currentTopicName` — constrain topic selection to a specific topic
+Optional flags:
+- `--branch-id` — test against a specific model branch
+- `--current-topic-name` — constrain topic selection to a specific topic
 
 ### Pick Topic
 
 Check which topic the AI would select for a question, without generating a full query:
 
 ```bash
-omni ai pick-topic --body '{
-  "modelId": "your-model-id",
-  "prompt": "How many users signed up last month?"
-}'
+omni ai pick-topic your-model-id "How many users signed up last month?"
 ```
 
 ### Agentic Queries (async)
@@ -263,10 +253,7 @@ For the full Blobby experience — multi-step analysis, tool use, and topic sele
 
 ```bash
 # 1. Submit a job
-omni ai job-submit --body '{
-  "modelId": "your-model-id",
-  "prompt": "Analyze revenue trends and identify our fastest growing product category"
-}'
+omni ai job-submit your-model-id "Analyze revenue trends and identify our fastest growing product category"
 # → returns { "jobId": "job-uuid", "conversationId": "conv-uuid" }
 
 # 2. Poll for completion (QUEUED → EXECUTING → COMPLETE)


### PR DESCRIPTION
## Summary
- Updates all skill docs to use the new CLI shorthand positional args and promoted flags introduced in exploreomni/cli#26
- Replaces `--body '{"modelId": "...", "prompt": "..."}'` patterns with `omni ai generate-query <model-id> "prompt"` style across 5 files
- Fixes parameter tables, prose references, and batch loop examples to match the new flag names (`--run-query`, `--branch-id`, `--current-topic-name`, `--clear-existing-draft`, etc.)

## Files changed
- `skills/omni-query/SKILL.md` — ai generate-query, pick-topic, job-submit examples
- `skills/omni-ai-eval/SKILL.md` — eval examples, parameter table, batch loop, A/B comparison section
- `skills/omni-content-builder/SKILL.md` — documents update/move/duplicate examples
- `skills/omni-content-explorer/SKILL.md` — folders create example
- `rules/omni-api-conventions.mdc` — command pattern documentation

## Test plan
- [ ] Verify each updated command example matches the shorthand definitions in exploreomni/cli#26
- [ ] Confirm no remaining `--body` usage for commands that now have shorthand support
- [ ] Check markdown table rendering (separator rows present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)