### PR TITLE
Add omni-integrations install instructions

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,65 @@
+{
+  "name": "omni-analytics",
+  "owner": {
+    "name": "Omni Analytics",
+    "email": "support@omni.co"
+  },
+  "metadata": {
+    "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
+    "version": "1.2.0"
+  },
+  "plugins": [
+    {
+      "name": "omni-analytics",
+      "source": "./",
+      "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
+      "version": "1.2.0",
+      "author": {
+        "name": "Omni Analytics"
+      },
+      "license": "Apache-2.0",
+      "keywords": [
+        "omni",
+        "ai",
+        "agentic-analytics",
+        "agents",
+        "mcp",
+        "data",
+        "analytics",
+        "bi",
+        "business-intelligence",
+        "semantic-layer",
+        "data-modeling",
+        "dashboards",
+        "queries",
+        "blobby",
+        "ai-context",
+        "embed",
+        "iframe",
+        "white-label"
+      ],
+      "category": "data"
+    },
+    {
+      "name": "omni-integrations",
+      "source": "./skills/omni-integrations",
+      "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Omni Analytics"
+      },
+      "license": "Apache-2.0",
+      "keywords": [
+        "omni",
+        "integrations",
+        "snowflake",
+        "semantic-views",
+        "databricks",
+        "metric-views",
+        "data-platforms",
+        "analytics"
+      ],
+      "category": "data"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -81,11 +81,7 @@ Install from Git URL:
 /add-plugin https://github.com/exploreomni/omni-agent-skills.git
 ```
 
-To also install the integrations plugin (Snowflake Semantic Views, etc.):
-
-```text
-/add-plugin https://github.com/exploreomni/omni-agent-skills/tree/main/skills/omni-integrations
-```
+> **Note**: The `omni-integrations` plugin is not yet separately installable via `/add-plugin` in Cursor — subdirectory plugin paths are not currently supported. To make both plugins available, use [Cursor's team marketplace import](https://cursor.com/docs/plugins) (Dashboard > Settings > Plugins > Import) with the same repo URL.
 
 <a id="install-cortex-code"></a>
 ### Cortex Code

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Marketplace install (recommended, run separately):
 /plugin install omni-analytics@omni-analytics
 ```
 
+To also install the integrations plugin (Snowflake Semantic Views, etc.):
+
+```bash
+/plugin install omni-integrations@omni-analytics
+```
+
 Git URL install (run separately):
 
 ```bash
@@ -60,6 +66,12 @@ Git URL install (run separately):
 /plugin install omni-analytics@omni-analytics
 ```
 
+To also install the integrations plugin:
+
+```bash
+/plugin install omni-integrations@omni-analytics
+```
+
 <a id="install-cursor"></a>
 ### Cursor
 
@@ -67,6 +79,12 @@ Install from Git URL:
 
 ```text
 /add-plugin https://github.com/exploreomni/omni-agent-skills.git
+```
+
+To also install the integrations plugin (Snowflake Semantic Views, etc.):
+
+```text
+/add-plugin https://github.com/exploreomni/omni-agent-skills/tree/main/skills/omni-integrations
 ```
 
 <a id="install-cortex-code"></a>
@@ -86,6 +104,13 @@ Install one skill directly:
 ```bash
 mkdir -p .cortex/skills
 cp -R skills/omni-query .cortex/skills/
+```
+
+Install the integrations skills (Snowflake Semantic Views, etc.):
+
+```bash
+mkdir -p .cortex/skills
+cp -R skills/omni-integrations .cortex/skills/
 ```
 
 <a id="install-skills-sh-compatible-agents"></a>
@@ -109,6 +134,12 @@ Install one skill directly:
 
 ```bash
 npx skills add https://github.com/exploreomni/omni-agent-skills --skill omni-query
+```
+
+Install the integrations skills (Snowflake Semantic Views, etc.):
+
+```bash
+npx skills add https://github.com/exploreomni/omni-agent-skills --skill omni-integrations
 ```
 
 Install globally:
@@ -239,7 +270,7 @@ To make this plugin available to your entire team automatically, add it to your 
       }
     }
   },
-  "enabledPlugins": ["omni-analytics@omni-analytics"]
+  "enabledPlugins": ["omni-analytics@omni-analytics", "omni-integrations@omni-analytics"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Install from Git URL:
 /add-plugin https://github.com/exploreomni/omni-agent-skills.git
 ```
 
-> **Note**: The `omni-integrations` plugin is not yet separately installable via `/add-plugin` in Cursor — subdirectory plugin paths are not currently supported. To make both plugins available, use [Cursor's team marketplace import](https://cursor.com/docs/plugins) (Dashboard > Settings > Plugins > Import) with the same repo URL.
+To also install the integrations plugin (Snowflake Semantic Views, etc.), use [Cursor's team marketplace import](https://cursor.com/docs/plugins) (Dashboard > Settings > Plugins > Import) with the repo URL `https://github.com/exploreomni/omni-agent-skills` — both `omni-analytics` and `omni-integrations` will appear as separate installable plugins.
 
 <a id="install-cortex-code"></a>
 ### Cortex Code
@@ -295,6 +295,7 @@ omni-agent-skills/
 │   ├── marketplace.json
 │   └── plugin.json
 ├── .cursor-plugin/
+│   ├── marketplace.json
 │   └── plugin.json
 ├── skills/
 │   ├── omni-model-explorer/

--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ omni-agent-skills/
 │   └── omni-integrations/
 │       ├── .claude-plugin/
 │       │   └── plugin.json
+│       ├── .cursor-plugin/
+│       │   └── plugin.json
 │       └── skills/
 │           └── omni-to-snowflake-semantic-view/
 ├── agents/


### PR DESCRIPTION
## Summary
- Added install instructions for the `omni-integrations` plugin across all platform sections (Claude Code, Cursor, Cortex Code, skills.sh-compatible agents)
- Updated Team Deployment config to include `omni-integrations` in `enabledPlugins`
- The integrations plugin (Snowflake Semantic Views, etc.) is a separate install target within the same marketplace that was previously undocumented

## Test plan
- [ ] Verify all install commands work as documented
- [ ] Confirm Cursor `/add-plugin` URL resolves correctly for the nested plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)