### PR TITLE
Add plugin update troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,33 @@ Or update manually from the `/plugin` menu.
 
 Re-run the installation command or re-copy the updated `skills/` folders to pull the latest version.
 
+### Plugin Update / Reinstall Issues (Claude Code)
+
+If `/plugin install` reports the plugin is "already installed globally" but `/reload-plugins` shows 0 skills loaded, the plugin registry is in a stale state. This can happen when `/plugin uninstall` doesn't fully clean up all entries.
+
+To fix, manually remove leftover registry data and reinstall:
+
+1. Edit `~/.claude/settings.json` and remove:
+   - The `"omni-analytics@omni-analytics"` entry from `enabledPlugins`
+   - The `"omni-analytics"` block from `extraKnownMarketplaces`
+
+2. Edit `~/.claude/plugins/installed_plugins.json` and remove the `omni-analytics` entry
+
+3. Edit `~/.claude/plugins/known_marketplaces.json` and remove the `omni-analytics` entry
+
+4. Delete cached files:
+   ```bash
+   rm -rf ~/.claude/plugins/cache/omni-analytics/
+   rm -rf ~/.claude/plugins/marketplaces/omni-analytics/
+   ```
+
+5. Reinstall fresh:
+   ```bash
+   /plugin marketplace add exploreomni/omni-agent-skills
+   /plugin install omni-analytics@omni-analytics
+   /reload-plugins
+   ```
+
 ## Repository Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -260,11 +260,13 @@ Or update manually from the `/plugin` menu.
 
 Re-run the installation command or re-copy the updated `skills/` folders to pull the latest version.
 
-### Plugin Update / Reinstall Issues (Claude Code)
+### Getting the Latest Version
 
-If `/plugin install` reports the plugin is "already installed globally" but `/reload-plugins` shows 0 skills loaded, the plugin registry is in a stale state. This can happen when `/plugin uninstall` doesn't fully clean up all entries.
+If your skills appear outdated, or the install command reports the plugin is "already installed" while skills aren't loading, your IDE may be serving a cached version. This can happen when the uninstall process doesn't fully clean up all registry and cache entries.
 
-To fix, manually remove leftover registry data and reinstall:
+To ensure you're running the latest version, manually clear the stale plugin data and reinstall.
+
+#### Claude Code
 
 1. Edit `~/.claude/settings.json` and remove:
    - The `"omni-analytics@omni-analytics"` entry from `enabledPlugins`
@@ -280,11 +282,28 @@ To fix, manually remove leftover registry data and reinstall:
    rm -rf ~/.claude/plugins/marketplaces/omni-analytics/
    ```
 
-5. Reinstall fresh:
+5. Reinstall the latest version:
    ```bash
    /plugin marketplace add exploreomni/omni-agent-skills
    /plugin install omni-analytics@omni-analytics
    /reload-plugins
+   ```
+
+#### Cursor
+
+1. Remove the plugin:
+   ```text
+   /remove-plugin omni-analytics
+   ```
+
+2. Delete the cached plugin clone:
+   ```bash
+   rm -rf ~/.cursor/plugins/omni-analytics/
+   ```
+
+3. Reinstall the latest version:
+   ```text
+   /add-plugin https://github.com/exploreomni/omni-agent-skills.git
    ```
 
 ## Repository Structure


### PR DESCRIPTION
## Summary

- Adds a troubleshooting section to the README for a common Claude Code plugin update issue
- Documents the fix for stale registry state where `/plugin install` reports "already installed globally" but `/reload-plugins` shows 0 skills loaded
- Includes step-by-step manual cleanup of `settings.json`, `installed_plugins.json`, `known_marketplaces.json`, and cached plugin files, followed by a fresh reinstall

## Test plan

- [ ] Verify the new section renders correctly in GitHub's markdown preview
- [ ] Confirm the cleanup steps resolve the described issue on a machine with stale plugin state

🤖 Generated with [Claude Code](https://claude.com/claude-code)