### PR TITLE
docs: add migration note for users coming from deprecated repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,32 @@ Update installed skills:
 npx skills update
 ```
 
+## Migrating from Older Repos
+
+This repo replaces two earlier, platform-specific repos that are now deprecated:
+
+| Deprecated repo | Replacement |
+|-----------------|-------------|
+| [`exploreomni/omni-claude-skills`](https://github.com/exploreomni/omni-claude-skills) | Use the [Claude Code install](#install-claude-code) above |
+| [`exploreomni/omni-cursor-plugin`](https://github.com/exploreomni/omni-cursor-plugin) | Use the [Cursor install](#install-cursor) above |
+
+If you previously installed from either repo, uninstall the old plugin first, then follow the installation instructions above.
+
+**Claude Code**
+
+```bash
+/plugin uninstall omni-analytics@omni-analytics
+/plugin marketplace remove omni-claude-skills
+```
+
+**Cursor**
+
+```text
+/remove-plugin omni-cursor-plugin
+```
+
+Then follow the [installation instructions](#installation) above to install from this repo.
+
 ## Setup
 
 ### Install the Omni CLI


### PR DESCRIPTION
## Summary

- Adds a "Migrating from Older Repos" section to the README between the Installation and Setup sections
- Provides uninstall commands for both Claude Code and Cursor users coming from the now-deprecated `omni-claude-skills` and `omni-cursor-plugin` repos
- Links users to the correct install instructions in this consolidated repo

## Test plan

- [ ] Verify the new section renders correctly on GitHub
- [ ] Confirm the anchor links (`#install-claude-code`, `#install-cursor`, `#installation`) resolve to the correct headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)