### PR TITLE
Add docs notification workflow for mintlify-omni

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -1,0 +1,30 @@
+name: Notify Docs on Changes
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - "**/*.mdc"
+      - "!.github/**"
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger mintlify-omni docs sync
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          repository: exploreomni/mintlify-omni
+          event-type: skills-docs-update
+          client-payload: >-
+            {
+              "source": "skills",
+              "trigger": "${{ github.event_name == 'release' && 'release' || 'push' }}",
+              "release_tag": "${{ github.event.release.tag_name || '' }}",
+              "commit_sha": "${{ github.sha }}",
+              "before_sha": "${{ github.event.before || '' }}"
+            }


### PR DESCRIPTION
## Summary
- Adds `notify-docs.yml` workflow that dispatches `skills-docs-update` events to `exploreomni/mintlify-omni`
- Triggers on release published AND when markdown/mdc files change on main
- Enables automated downstream documentation sync

## How it works
```
Skills repo README/doc changes on main (or release published)
  → notify-docs.yml fires repository_dispatch to mintlify-omni
  → mintlify-omni/sync-upstream-docs.yml processes the change
  → Claude Code analyzes diff, updates MDX docs, creates PR
  → /review comment triggers automated doc review
```

## Secrets required
- `DOCS_REPO_TOKEN` — fine-grained PAT (`write-to-mintlify-omni`) with Contents: Read and write, scoped to `exploreomni/mintlify-omni` only

## Related PRs
- exploreomni/mintlify-omni#1099 — receiver workflow (merge first)
- exploreomni/cli#30 — CLI sender

## Test plan
- [ ] Configure `DOCS_REPO_TOKEN` secret with fine-grained PAT
- [ ] Merge receiver PR in mintlify-omni first
- [ ] Push a doc change to main and verify dispatch fires
- [ ] Verify mintlify-omni creates a docs sync PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)