### PR TITLE
Switch install instructions from curl | sh to brew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,14 @@ Then follow the [installation instructions](#installation) above to install from
 
 ### Install the Omni CLI
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
-This downloads the latest release, verifies the SHA-256 checksum, and installs the `omni` binary to `/usr/local/bin` (or `~/.local/bin` if not writable). Pre-built binaries for all platforms are also available on the [GitHub Releases page](https://github.com/exploreomni/cli/releases).
+Pre-built binaries for macOS (amd64/arm64), Linux (amd64/arm64), and Windows (amd64) are also available on the [GitHub Releases page](https://github.com/exploreomni/cli/releases).
 
 ### Configure authentication
 

--- a/rules/omni-api-conventions.mdc
+++ b/rules/omni-api-conventions.mdc
@@ -10,9 +10,11 @@ alwaysApply: false
 
 If the `omni` command is not available, install it:
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 Pre-built binaries for macOS (amd64/arm64), Linux (amd64/arm64), and Windows (amd64) are available on the [GitHub Releases page](https://github.com/exploreomni/cli/releases).

--- a/skills/omni-admin/SKILL.md
+++ b/skills/omni-admin/SKILL.md
@@ -11,8 +11,11 @@ Manage your Omni instance — connections, users, groups, user attributes, permi
 
 ## Prerequisites
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash

--- a/skills/omni-ai-eval/SKILL.md
+++ b/skills/omni-ai-eval/SKILL.md
@@ -11,8 +11,11 @@ Run evals against Omni's AI query generation APIs — submit test prompts, captu
 
 ## Prerequisites
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash

--- a/skills/omni-ai-optimizer/SKILL.md
+++ b/skills/omni-ai-optimizer/SKILL.md
@@ -11,8 +11,11 @@ Optimize your Omni semantic model so Blobby (the Omni Agent) returns accurate, c
 
 ## Prerequisites
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -20,8 +20,11 @@ Create, update, and manage Omni documents and dashboards programmatically via th
 
 ## Prerequisites
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash

--- a/skills/omni-content-explorer/SKILL.md
+++ b/skills/omni-content-explorer/SKILL.md
@@ -9,8 +9,11 @@ Find, browse, and organize Omni content â€” dashboards, workbooks, and folders â
 
 ## Prerequisites
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash

--- a/skills/omni-embed/SKILL.md
+++ b/skills/omni-embed/SKILL.md
@@ -15,8 +15,11 @@ Embed Omni dashboards in external applications using signed iframe URLs. The `@o
 npm install @omni-co/embed
 ```
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash

--- a/skills/omni-integrations/skills/omni-to-databricks-metric-views/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-databricks-metric-views/SKILL.md
@@ -13,9 +13,11 @@ See [FIELD-MAPPING.md](./references/FIELD-MAPPING.md) for full before/after tran
 
 ## Prerequisites
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-# Omni CLI
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash

--- a/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
@@ -11,8 +11,11 @@ Converts an Omni topic into a Snowflake Semantic View YAML definition by first e
 
 ## Prerequisites
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -11,8 +11,11 @@ Create and modify Omni's semantic model through the YAML API — views, topics, 
 
 ## Prerequisites
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -13,8 +13,11 @@ Explore and understand an Omni semantic model through the Omni CLI. This is the 
 
 Configure the Omni CLI:
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -11,8 +11,11 @@ Run queries against Omni's semantic layer via the Omni CLI. Omni translates fiel
 
 ## Prerequisites
 
+> Requires Homebrew. For other installation methods, see the [CLI README](https://github.com/exploreomni/cli#installation).
+
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+brew tap exploreomni/tap
+brew install omni
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

- Replaces `curl -fsSL .../install.sh | sh` with `brew tap exploreomni/tap && brew install omni` across all skills, rules, and README
- Adds a markdown note above each install block pointing to the [CLI README](https://github.com/exploreomni/cli#installation) for non-Homebrew installation methods

## Motivation

The `curl | sh` pattern is flagged as high severity by Snyk Agent Scan (E005/W012). Switching to Homebrew resolves all install-related findings — confirmed clean on a full scan.

## Depends on

Requires exploreomni/cli#32 (homebrew tap support) to be merged before this can be used in production.

## Test plan

- [x] Ran `uvx snyk-agent-scan@latest --skills skills/` before and after — all `curl | sh` findings resolved
- [ ] Verify `brew tap exploreomni/tap && brew install omni` works once exploreomni/cli#32 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)