### PR TITLE
Replace CLI auto-install with check-and-prompt

### DIFF
--- a/skills/omni-admin/SKILL.md
+++ b/skills/omni-admin/SKILL.md
@@ -12,7 +12,9 @@ Manage your Omni instance — connections, users, groups, user attributes, permi
 ## Prerequisites
 
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash

--- a/skills/omni-ai-eval/SKILL.md
+++ b/skills/omni-ai-eval/SKILL.md
@@ -12,7 +12,9 @@ Run evals against Omni's AI query generation APIs — submit test prompts, captu
 ## Prerequisites
 
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash

--- a/skills/omni-ai-optimizer/SKILL.md
+++ b/skills/omni-ai-optimizer/SKILL.md
@@ -12,7 +12,9 @@ Optimize your Omni semantic model so Blobby (the Omni Agent) returns accurate, c
 ## Prerequisites
 
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -21,7 +21,9 @@ Create, update, and manage Omni documents and dashboards programmatically via th
 ## Prerequisites
 
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash

--- a/skills/omni-content-explorer/SKILL.md
+++ b/skills/omni-content-explorer/SKILL.md
@@ -10,7 +10,9 @@ Find, browse, and organize Omni content — dashboards, workbooks, and folders �
 ## Prerequisites
 
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash

--- a/skills/omni-embed/SKILL.md
+++ b/skills/omni-embed/SKILL.md
@@ -16,7 +16,9 @@ npm install @omni-co/embed
 ```
 
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash

--- a/skills/omni-integrations/skills/omni-to-databricks-metric-views/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-databricks-metric-views/SKILL.md
@@ -14,8 +14,9 @@ See [FIELD-MAPPING.md](./references/FIELD-MAPPING.md) for full before/after tran
 ## Prerequisites
 
 ```bash
-# Omni CLI
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash

--- a/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
@@ -12,7 +12,9 @@ Converts an Omni topic into a Snowflake Semantic View YAML definition by first e
 ## Prerequisites
 
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -12,7 +12,9 @@ Create and modify Omni's semantic model through the YAML API — views, topics, 
 ## Prerequisites
 
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -14,7 +14,9 @@ Explore and understand an Omni semantic model through the Omni CLI. This is the 
 Configure the Omni CLI:
 
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -12,7 +12,9 @@ Run queries against Omni's semantic layer via the Omni CLI. Omni translates fiel
 ## Prerequisites
 
 ```bash
-command -v omni >/dev/null || curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh
+# Verify the Omni CLI is installed — if not, ask the user to install it
+# See: https://github.com/exploreomni/cli#readme
+command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash


### PR DESCRIPTION
## Summary
- Removes the `curl | sh` auto-install of the Omni CLI from all 11 skill prerequisites sections
- Replaces with a `command -v omni` check that prints an error and links to the [CLI README](https://github.com/exploreomni/cli#readme) for installation instructions
- Skills now ask the user to install the CLI rather than silently installing it

## Files changed
All `SKILL.md` files across: omni-admin, omni-ai-eval, omni-ai-optimizer, omni-content-builder, omni-content-explorer, omni-embed, omni-model-builder, omni-model-explorer, omni-query, omni-to-snowflake-semantic-view, omni-to-databricks-metric-views

## Test plan
- [ ] Verify skills detect missing CLI and surface the error message
- [ ] Verify the README link is correct and helpful

🤖 Generated with [Claude Code](https://claude.com/claude-code)