### PR TITLE
Add eval scenarios for all 9 skills

### DIFF
--- a/evals/scenarios/omni-admin.eval.yaml
+++ b/evals/scenarios/omni-admin.eval.yaml
@@ -1,0 +1,66 @@
+skill: omni-admin
+skill_path: skills/omni-admin/SKILL.md
+
+config:
+  runs_per_config: 3
+  model: claude-sonnet-4-20250514
+
+scenarios:
+  - id: create-user
+    name: "Create a new user via SCIM"
+    prompt: "Create a new user with email 'testeval@example.com' and display name 'Test Eval User'."
+    category: user-management
+    difficulty: easy
+    assertions:
+      - type: tool_called
+        pattern: "omni scim users-create"
+        description: "Ran omni scim users-create to provision the user"
+      - type: output_contains
+        value: "testeval@example.com"
+        description: "Payload includes the correct email address"
+      - type: output_contains
+        value: "urn:ietf:params:scim:schemas:core:2.0:User"
+        description: "Uses the SCIM 2.0 user schema"
+      - type: tool_called
+        pattern: "omni scim users-list"
+        description: "Attempted verification with users-list after creation"
+
+  - id: set-permissions
+    name: "Set view permissions on a dashboard"
+    prompt: "Give the 'Analytics Team' group view access to a dashboard."
+    category: permissions
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni documents update-permission"
+        description: "Ran document permission update command"
+      - type: output_contains
+        value: "view"
+        description: "Permission level specified as view"
+      - type: tool_called
+        pattern: "omni documents get-permissions"
+        description: "Attempted to verify permissions after setting them"
+
+  - id: configure-schedule
+    name: "Set up a weekly PDF delivery schedule"
+    prompt: "Set up a weekly PDF delivery of a dashboard every Monday at 9am."
+    category: scheduling
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni schedules create"
+        description: "Ran schedule creation command"
+      - type: output_contains_all
+        values:
+          - "weekly"
+          - "monday"
+        description: "Schedule specifies weekly on Monday"
+      - type: output_contains
+        value: "pdf"
+        description: "Format is PDF"
+      - type: output_contains_any
+        values:
+          - "recipient"
+          - "email"
+          - "add-recipients"
+        description: "Includes or mentions recipient configuration"

--- a/evals/scenarios/omni-ai-eval.eval.yaml
+++ b/evals/scenarios/omni-ai-eval.eval.yaml
@@ -1,0 +1,75 @@
+skill: omni-ai-eval
+skill_path: skills/omni-ai-eval/SKILL.md
+
+config:
+  runs_per_config: 3
+  model: claude-sonnet-4-20250514
+
+scenarios:
+  - id: run-single-eval
+    name: "Run a single AI eval case"
+    prompt: "Run a single AI eval: test if Blobby can correctly generate a query for 'Show me revenue by month' against the Pg model."
+    category: eval-execution
+    difficulty: easy
+    assertions:
+      - type: tool_called
+        pattern: "omni ai generate-query"
+        description: "Ran omni ai generate-query to test AI output"
+      - type: output_contains
+        value: "--run-query false"
+        description: "Passed --run-query false to get only the query structure"
+      - type: output_contains_any
+        values:
+          - "fields"
+          - "query"
+        description: "Output shows the generated query structure"
+      - type: output_contains_any
+        values:
+          - "revenue"
+          - "month"
+          - "created_at"
+        description: "Compares generated fields against expected"
+
+  - id: batch-eval
+    name: "Run a batch of eval cases"
+    prompt: "Set up and run a batch of 3 eval cases testing different query types: aggregation, filtering, and sorting."
+    category: eval-execution
+    difficulty: hard
+    assertions:
+      - type: output_contains_any
+        values:
+          - "jsonl"
+          - "JSONL"
+          - "eval_cases"
+          - "eval cases"
+        description: "Created eval cases in JSONL or structured format"
+      - type: output_count_gte
+        pattern: "omni ai generate-query"
+        min_count: 3
+        description: "Ran multiple generate-query calls for the batch"
+      - type: output_contains_any
+        values:
+          - "pass"
+          - "fail"
+          - "result"
+          - "score"
+        description: "Output shows per-case results"
+
+  - id: ab-comparison
+    name: "A/B eval comparison across branches"
+    prompt: "Compare AI accuracy on main vs a branch. Explain how to set up an A/B eval comparison."
+    category: eval-methodology
+    difficulty: medium
+    assertions:
+      - type: output_contains
+        value: "--branch-id"
+        description: "Describes running evals with different --branch-id values"
+      - type: output_contains_any
+        values:
+          - "regression"
+          - "comparison"
+          - "delta"
+        description: "Mentions regression detection or comparison methodology"
+      - type: llm_judge
+        criteria: "The response provides a clear A/B comparison methodology: run the same eval set with two configurations (e.g., main vs branch), score both, and compare results side-by-side checking for regressions and improvements."
+        description: "Provides a clear A/B comparison methodology"

--- a/evals/scenarios/omni-ai-optimizer.eval.yaml
+++ b/evals/scenarios/omni-ai-optimizer.eval.yaml
@@ -1,0 +1,64 @@
+skill: omni-ai-optimizer
+skill_path: skills/omni-ai-optimizer/SKILL.md
+
+config:
+  runs_per_config: 3
+  model: claude-sonnet-4-20250514
+
+scenarios:
+  - id: inspect-ai-config
+    name: "Inspect AI context on a topic"
+    prompt: "What AI context and configuration exists on the order_items topic in the Pg model?"
+    category: inspection
+    difficulty: easy
+    assertions:
+      - type: tool_called
+        pattern: "omni models"
+        description: "Ran omni models get-topic or yaml-get to inspect the topic"
+      - type: output_contains
+        value: "ai_context"
+        description: "Output mentions ai_context"
+      - type: output_contains_any
+        values:
+          - "sample_queries"
+          - "ai_fields"
+          - "no sample_queries"
+          - "no ai_fields"
+        description: "Output describes sample_queries or ai_fields presence"
+
+  - id: add-sample-queries
+    name: "Add sample queries to a topic"
+    prompt: "Add 3 sample queries to the order_items topic to help the AI understand common questions."
+    category: optimization
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "yaml-"
+        description: "Used yaml-update or yaml-create on a branch"
+      - type: output_contains
+        value: "sample_queries"
+        description: "sample_queries field is present in the update"
+      - type: llm_judge
+        criteria: "The sample queries added are realistic data questions that a business user would ask about order items, such as questions about revenue, order counts, trends, or top products."
+        description: "Sample queries are realistic data questions"
+
+  - id: configure-ai-fields
+    name: "Configure ai_fields to hide internal fields"
+    prompt: "Configure ai_fields on the order_items topic to hide internal fields from the AI."
+    category: optimization
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "yaml-"
+        description: "Used yaml-update or yaml-create to modify the topic"
+      - type: output_contains
+        value: "ai_fields"
+        description: "ai_fields configuration is present"
+      - type: output_contains_any
+        values:
+          - "-"
+          - "include"
+          - "exclude"
+          - "hidden"
+          - "tag:internal"
+        description: "Specifies include or exclude pattern for fields"

--- a/evals/scenarios/omni-content-builder.eval.yaml
+++ b/evals/scenarios/omni-content-builder.eval.yaml
@@ -1,0 +1,90 @@
+skill: omni-content-builder
+skill_path: skills/omni-content-builder/SKILL.md
+
+config:
+  runs_per_config: 3
+  model: claude-sonnet-4-20250514
+
+scenarios:
+  - id: create-dashboard
+    name: "Create a dashboard with a line chart"
+    prompt: "Create a dashboard called 'Revenue Overview' showing monthly revenue as a line chart. Use the Pg model and order_items topic."
+    category: dashboard-creation
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni models validate"
+        description: "Validated the model before building"
+      - type: tool_called
+        pattern: "omni query run"
+        description: "Tested the query before creating the dashboard"
+      - type: tool_called
+        pattern: "omni documents create"
+        description: "Ran omni documents create to build the dashboard"
+      - type: output_contains
+        value: "queryPresentation"
+        description: "Creation payload includes queryPresentations"
+      - type: tool_called
+        pattern: "omni documents get"
+        description: "Verified the dashboard after creation"
+
+  - id: multi-tile-dashboard
+    name: "Build a multi-tile dashboard"
+    prompt: "Build a dashboard with 2 tiles: monthly revenue trend and top 5 products by revenue."
+    category: dashboard-creation
+    difficulty: hard
+    assertions:
+      - type: output_count_gte
+        pattern: "omni query run"
+        min_count: 2
+        description: "Tested both queries before building the dashboard"
+      - type: output_regex
+        pattern: "queryPresentation.*queryPresentation|tiles.*2|two.*tile"
+        description: "Creation payload has 2 tiles"
+      - type: llm_judge
+        criteria: "The dashboard creation payload includes two tiles with appropriate visualization configurations -- one for a time-series trend and one for a top-N ranking."
+        description: "Tiles have appropriate viz configurations"
+
+  - id: add-filter
+    name: "Add a date filter to an existing dashboard"
+    prompt: "Add a date filter for the last 30 days to an existing dashboard."
+    category: dashboard-update
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni documents get"
+        description: "Inspected the existing dashboard first"
+      - type: output_contains_any
+        values:
+          - "filterConfig"
+          - "filter"
+          - "update"
+        description: "Used update with filter configuration"
+      - type: output_contains_any
+        values:
+          - "created_at"
+          - "date"
+          - "TIME_FOR_INTERVAL"
+        description: "Filter targets a date field"
+
+  - id: validation-loop
+    name: "Full validation workflow for a KPI dashboard"
+    prompt: "Create a simple KPI dashboard showing total revenue. Follow the full validation workflow."
+    category: workflow
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni models validate"
+        description: "Pre-build validation: ran model validate"
+      - type: tool_called
+        pattern: "omni query run"
+        description: "Pre-build validation: tested the query"
+      - type: tool_called
+        pattern: "omni documents create"
+        description: "Created the document"
+      - type: tool_called
+        pattern: "omni documents get"
+        description: "Post-build verification: read back the dashboard"
+      - type: step_count_lte
+        max_steps: 15
+        description: "Completed the full workflow within 15 steps"

--- a/evals/scenarios/omni-content-explorer.eval.yaml
+++ b/evals/scenarios/omni-content-explorer.eval.yaml
@@ -1,0 +1,67 @@
+skill: omni-content-explorer
+skill_path: skills/omni-content-explorer/SKILL.md
+
+config:
+  runs_per_config: 3
+  model: claude-sonnet-4-20250514
+
+scenarios:
+  - id: search-dashboards
+    name: "Search for dashboards by topic"
+    prompt: "Find any dashboards related to 'revenue' or 'sales' in our Omni instance."
+    category: content-discovery
+    difficulty: easy
+    assertions:
+      - type: tool_called
+        pattern: "omni documents list"
+        description: "Ran omni documents list or omni documents search to find content"
+      - type: output_contains_any
+        values:
+          - "name"
+          - "title"
+          - "dashboard"
+        description: "Output lists document names or titles"
+      - type: output_contains
+        value: "identifier"
+        description: "Output includes document identifiers"
+
+  - id: list-content
+    name: "List root folder content"
+    prompt: "Show me what's in the root folder of our Omni instance."
+    category: content-discovery
+    difficulty: easy
+    assertions:
+      - type: tool_called
+        pattern: "omni documents list"
+        description: "Ran omni documents list to browse content"
+      - type: output_contains_any
+        values:
+          - "folder"
+          - "document"
+          - "records"
+        description: "Output shows folders or documents"
+      - type: output_contains_any
+        values:
+          - "dashboard"
+          - "workbook"
+          - "hasDashboard"
+        description: "Mentions document types"
+
+  - id: download-dashboard
+    name: "Download a dashboard as PDF"
+    prompt: "Download a PDF of our most recent dashboard."
+    category: content-export
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni documents list"
+        description: "Ran omni documents list to find a dashboard first"
+      - type: tool_called
+        pattern: "omni dashboards download"
+        description: "Ran omni dashboards download to export"
+      - type: output_contains_any
+        values:
+          - "pdf"
+          - "png"
+          - "format"
+        description: "Mentioned PDF or PNG format option"

--- a/evals/scenarios/omni-embed.eval.yaml
+++ b/evals/scenarios/omni-embed.eval.yaml
@@ -1,0 +1,81 @@
+skill: omni-embed
+skill_path: skills/omni-embed/SKILL.md
+
+config:
+  runs_per_config: 3
+  model: claude-sonnet-4-20250514
+
+scenarios:
+  - id: sign-embed-url
+    name: "Generate a signed embed URL"
+    prompt: "Generate a signed embed URL for dashboard ID 'abc123' with user email 'viewer@company.com'."
+    category: embed-signing
+    difficulty: medium
+    assertions:
+      - type: output_contains_any
+        values:
+          - "embedSsoDashboard"
+          - "embed"
+          - "@omni-co/embed"
+        description: "References the @omni-co/embed SDK or embed signing function"
+      - type: output_contains_any
+        values:
+          - "secret"
+          - "OMNI_EMBED_SECRET"
+        description: "Mentions the embed secret for URL signing"
+      - type: output_contains
+        value: "viewer@company.com"
+        description: "Includes the user email in the signed payload"
+      - type: output_contains_any
+        values:
+          - "contentId"
+          - "abc123"
+        description: "References the dashboard ID"
+
+  - id: configure-theme
+    name: "Set up a custom embed theme"
+    prompt: "Set up a custom embed theme with our brand colors: primary #1a73e8, background white."
+    category: embed-theming
+    difficulty: medium
+    assertions:
+      - type: output_contains_any
+        values:
+          - "customTheme"
+          - "themeOverrides"
+          - "custom_theme"
+        description: "Describes theme configuration using customTheme"
+      - type: output_contains_any
+        values:
+          - "#1a73e8"
+          - "1a73e8"
+        description: "Includes the specified brand color value"
+      - type: output_contains_any
+        values:
+          - "dashboard-key-color"
+          - "dashboard-background"
+          - "dashboard-tile-background"
+        description: "References specific theme properties"
+
+  - id: entity-workspace
+    name: "Explain entity workspaces for multi-tenant embedding"
+    prompt: "Explain how to set up entity workspaces for multi-tenant embedding where each customer sees only their data."
+    category: embed-architecture
+    difficulty: hard
+    assertions:
+      - type: output_contains_any
+        values:
+          - "entity"
+          - "entity workspace"
+          - "entityFolderContentRole"
+        description: "Output describes entity workspaces"
+      - type: output_contains_any
+        values:
+          - "userAttributes"
+          - "user_attributes"
+          - "user attributes"
+          - "access_filter"
+          - "row-level security"
+        description: "Mentions user attributes or row-level security"
+      - type: llm_judge
+        criteria: "The explanation clearly describes how entity workspaces isolate data between tenants, covering how each customer gets a scoped folder and how user attributes or access filters ensure they only see their own data."
+        description: "Explanation covers data isolation between tenants"

--- a/evals/scenarios/omni-model-builder.eval.yaml
+++ b/evals/scenarios/omni-model-builder.eval.yaml
@@ -1,0 +1,88 @@
+skill: omni-model-builder
+skill_path: skills/omni-model-builder/SKILL.md
+
+config:
+  runs_per_config: 3
+  model: claude-sonnet-4-20250514
+
+scenarios:
+  - id: add-dimension
+    name: "Add a dimension on a model branch"
+    prompt: "Add a new dimension called 'order_year' to the order_items view that extracts the year from created_at. Do this on a branch."
+    category: model-editing
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni models create-branch"
+        description: "Created a model branch for safe development"
+      - type: tool_called
+        pattern: "yaml-update"
+        description: "Used yaml-update or yaml-set to write the dimension"
+      - type: output_contains_any
+        values:
+          - "EXTRACT(YEAR"
+          - "DATE_PART"
+          - "year"
+        description: "Dimension SQL uses year extraction from created_at"
+      - type: tool_called
+        pattern: "omni models validate"
+        description: "Validated the model changes"
+
+  - id: create-topic
+    name: "Create a new topic with joins"
+    prompt: "Create a new topic called 'user_orders' with users as the base view, joined to order_items."
+    category: model-editing
+    difficulty: hard
+    assertions:
+      - type: output_contains_any
+        values:
+          - "topic"
+          - ".topic"
+        description: "Topic creation was attempted"
+      - type: output_contains
+        value: "users"
+        description: "Specifies users as the base view"
+      - type: output_contains_any
+        values:
+          - "order_items"
+          - "join"
+          - "relationship"
+        description: "Includes a join or relationship definition to order_items"
+      - type: tool_called
+        pattern: "omni models validate"
+        description: "Ran model validation after creating the topic"
+
+  - id: add-measure
+    name: "Add a sum measure to a view"
+    prompt: "Add a sum measure for 'total_quantity' on the order_items view using the quantity field."
+    category: model-editing
+    difficulty: easy
+    assertions:
+      - type: tool_called
+        pattern: "yaml-"
+        description: "Used a yaml modification command"
+      - type: output_contains
+        value: "sum"
+        description: "Measure has aggregate_type sum"
+      - type: output_contains
+        value: "quantity"
+        description: "Measure references the quantity field"
+
+  - id: branch-workflow
+    name: "Demonstrate the full branch workflow"
+    prompt: "Show me how to create a model branch, make a change, validate it, and see the diff."
+    category: workflow
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "create-branch"
+        description: "Ran branch-create to start a new branch"
+      - type: tool_called
+        pattern: "yaml-"
+        description: "Ran a yaml modification command"
+      - type: tool_called
+        pattern: "validate"
+        description: "Ran model validation"
+      - type: tool_called
+        pattern: "yaml-get"
+        description: "Ran yaml-get or branch-diff to show changes"

--- a/evals/scenarios/omni-model-explorer.eval.yaml
+++ b/evals/scenarios/omni-model-explorer.eval.yaml
@@ -1,0 +1,131 @@
+skill: omni-model-explorer
+skill_path: skills/omni-model-explorer/SKILL.md
+
+config:
+  runs_per_config: 3
+  model: claude-sonnet-4-20250514
+
+scenarios:
+  - id: list-models
+    name: "List available models and identify shared model"
+    prompt: "What models are available in our Omni instance? Which one is the shared model?"
+    category: model-discovery
+    difficulty: easy
+    assertions:
+      - type: tool_called
+        pattern: "omni models list"
+        description: "Ran omni models list to discover available models"
+      - type: output_contains_any
+        values:
+          - "SHARED"
+          - "modelKind"
+        description: "Output mentions SHARED or modelKind"
+      - type: output_contains
+        value: "Pg"
+        description: "Output includes the Pg model"
+      - type: output_regex
+        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        description: "Output includes a model ID UUID"
+
+  - id: explore-views
+    name: "Explore views and fields in a model"
+    prompt: "Show me all the views and example fields in the Pg model. Use the model YAML."
+    category: model-inspection
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni models yaml-get"
+        description: "Used yaml-get to inspect the model YAML"
+      - type: output_contains_all
+        values:
+          - "order_items"
+          - "users"
+          - "inventory_items"
+          - "products"
+          - "distribution_centers"
+          - "events"
+        description: "Output lists all 6 views in the Pg model"
+      - type: output_regex
+        pattern: "\\w+\\.\\w+"
+        description: "Output includes field names using view.field notation"
+      - type: output_contains
+        value: "count"
+        description: "Output mentions a count measure"
+
+  - id: inspect-relationships
+    name: "Inspect join relationships between views"
+    prompt: "How do the views in the Pg model relate to each other? Show me the join conditions and relationship types."
+    category: model-inspection
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni models yaml-get"
+        description: "Inspected model via yaml-get"
+      - type: output_contains
+        value: "user_id"
+        description: "Describes order_items to users join with user_id"
+      - type: output_contains_any
+        values:
+          - "inventory_items"
+          - "inventory_item_id"
+        description: "Describes order_items to inventory_items join"
+      - type: output_contains_all
+        values:
+          - "products"
+          - "distribution_centers"
+        description: "Describes products to distribution_centers join"
+      - type: output_contains_any
+        values:
+          - "join_type"
+          - "relationship"
+          - "many_to_one"
+          - "one_to_many"
+        description: "Mentions join type or relationship type"
+
+  - id: list-topics
+    name: "List topics and their views"
+    prompt: "What topics exist in the Pg model? What views are available in each?"
+    category: model-discovery
+    difficulty: medium
+    assertions:
+      - type: output_contains_all
+        values:
+          - "order_items"
+          - "events"
+        description: "Identifies both order_items and events topics"
+      - type: output_contains_any
+        values:
+          - "join"
+          - "view"
+          - "relationship"
+        description: "Describes joins or views available in topics"
+      - type: llm_judge
+        criteria: "If the agent's list-topics command fails or is unavailable, the agent falls back to using yaml-get or another method to discover topics rather than giving up."
+        description: "Falls back gracefully if list-topics is unavailable"
+      - type: output_not_contains
+        value: "access denied"
+        description: "Does not fabricate access errors"
+
+  - id: field-impact
+    name: "Assess field removal impact"
+    prompt: "What would break if we removed the 'sale_price' field from order_items? Check model references and dashboard impact."
+    category: impact-analysis
+    difficulty: hard
+    assertions:
+      - type: tool_called
+        pattern: "omni models yaml-get"
+        description: "Searched model YAML for sale_price references"
+      - type: output_contains_any
+        values:
+          - "content validator"
+          - "content-validator"
+          - "validate"
+        description: "Mentions content validator for dashboard impact"
+      - type: output_contains_all
+        values:
+          - "sale_price"
+          - "order_items"
+        description: "Identifies sale_price in order_items view"
+      - type: llm_judge
+        criteria: "The agent does not fabricate specific dashboard names or content that references sale_price. It either finds real references or honestly states it cannot determine dashboard impact without further investigation."
+        description: "Does not fabricate dashboard names"

--- a/evals/scenarios/omni-query.eval.yaml
+++ b/evals/scenarios/omni-query.eval.yaml
@@ -1,0 +1,81 @@
+skill: omni-query
+skill_path: skills/omni-query/SKILL.md
+
+config:
+  runs_per_config: 3
+  model: claude-sonnet-4-20250514
+
+scenarios:
+  - id: simple-query
+    name: "Run a basic revenue by month query"
+    prompt: "Query the order_items topic for total revenue by month. Use the Pg model."
+    category: query-execution
+    difficulty: easy
+    assertions:
+      - type: tool_called
+        pattern: "omni query run"
+        description: "Ran a query using the Omni CLI"
+      - type: output_contains
+        value: "created_at"
+        description: "Output includes a date dimension"
+      - type: output_contains_any
+        values:
+          - "total_revenue"
+          - "revenue"
+        description: "Output includes a revenue measure"
+      - type: output_not_contains
+        value: "error"
+        description: "No error in the query response"
+
+  - id: filtered-query
+    name: "Run a filtered query with grouping"
+    prompt: "Show me order count by status for orders created in the last 90 days."
+    category: query-execution
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni query run"
+        description: "Ran a query using the Omni CLI"
+      - type: output_contains
+        value: "last 90 days"
+        description: "Filter expression for last 90 days is present"
+      - type: output_contains
+        value: "status"
+        description: "Groups results by status"
+      - type: output_contains_any
+        values:
+          - "count"
+          - "order_count"
+        description: "Includes a count measure"
+
+  - id: ai-generate-query
+    name: "Generate a query using AI without executing"
+    prompt: "Use Omni's AI to generate a query for 'top 10 customers by spend'. Don't execute it, just show the query structure."
+    category: ai-generation
+    difficulty: medium
+    assertions:
+      - type: tool_called
+        pattern: "omni ai generate-query"
+        description: "Used the AI generate-query command"
+      - type: output_contains
+        value: "--run-query false"
+        description: "Passed --run-query false to skip execution"
+      - type: output_contains
+        value: "sort_descending"
+        description: "Result includes a descending sort for top N pattern"
+
+  - id: multi-step-analysis
+    name: "Multi-step revenue trend analysis"
+    prompt: "What's our revenue trend? Show monthly revenue and identify the best and worst months."
+    category: analysis
+    difficulty: hard
+    assertions:
+      - type: tool_called
+        pattern: "omni query run"
+        description: "Ran at least one query"
+      - type: output_contains
+        value: "csv"
+        description: "Requested CSV format for readable results"
+      - type: llm_judge
+        criteria: "The agent identifies specific months with actual revenue numbers, naming the best and worst performing months with their values."
+        description: "Identifies specific best and worst months with numbers"


### PR DESCRIPTION
## Summary
Eval scenarios for all 9 Omni Analytics skills, covering 32 scenarios total with assertion-based grading.

| Skill | Scenarios | Assertions |
|-------|-----------|------------|
| omni-model-explorer | 5 | 18 |
| omni-query | 4 | 12 |
| omni-model-builder | 4 | ~14 |
| omni-content-explorer | 3 | ~10 |
| omni-content-builder | 4 | ~14 |
| omni-ai-optimizer | 3 | ~10 |
| omni-admin | 3 | ~11 |
| omni-embed | 3 | ~10 |
| omni-ai-eval | 3 | ~10 |

Each scenario runs 3x in both "with skill" and "without skill" configs. Assertion types used: tool_called, output_contains, output_contains_all, output_contains_any, output_not_contains, output_regex, llm_judge, step_count_lte.

Depends on #38 for the framework scripts.

## Test plan
- [ ] All YAML files parse correctly with `yq`
- [ ] Scenario prompts are clear and self-contained
- [ ] Assertions test meaningful skill-taught behaviors (not generic agent capabilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @ernestoongaro