### PR TITLE
Add changelog and versioning guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this repository will be documented in this file.
+
+Changelog tracking begins with the next release. Historical releases are not backfilled.
+
+The versions documented here should match the published plugin versions in the affected manifest files.
+
+## Unreleased
+
+No unreleased changes yet.

--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ omni-agent-skills/
 ├── assets/
 │   ├── logo.svg
 │   └── omni-agent-skills-banner.svg
+├── CHANGELOG.md
 ├── README.md
 └── LICENSE
 ```
@@ -414,6 +415,17 @@ omni-agent-skills/
 ## Contributing
 
 Contributions welcome! This is the single source of truth for all Omni Analytics agent skills. Please open an issue or PR.
+
+### Versioning and Changelog
+
+Use semantic versioning for published plugin changes. If you change distributed plugin behavior or metadata and do not bump the affected versions, existing installs may not pick up the update cleanly.
+
+This repo currently duplicates version metadata across `plugin.json` and `marketplace.json`. Until that is centralized, keep all affected version fields in sync:
+
+- `omni-analytics`: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, `.cursor-plugin/marketplace.json`
+- `omni-integrations`: `skills/omni-integrations/.claude-plugin/plugin.json`, `skills/omni-integrations/.cursor-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`
+
+Document user-visible changes in `CHANGELOG.md`. Changelog tracking starts with the next release and does not backfill older versions.
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds the minimal versioning/changelog documentation requested in issue #11 without trying to reconstruct historical release notes.

## What changed

- adds a root `CHANGELOG.md`
- makes the changelog explicitly forward-only, starting with the next release
- documents versioning expectations in `README.md`
- lists the plugin manifest files that contributors need to keep in sync today

## Why

The repo needed a clear place for release notes and clearer contributor guidance on which version fields to bump when publishing plugin changes.

## User impact

Contributors now have an explicit versioning checklist, and future releases have a single changelog entry point.

## Validation

- reviewed staged diff
- ran `git diff --cached --check`

Closes #11