### PR TITLE
Release: omni-analytics v1.3.0, omni-integrations v1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Omni Analytics"
       },
@@ -44,7 +44,7 @@
       "name": "omni-integrations",
       "source": "./skills/omni-integrations",
       "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, and more.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {
     "name": "Omni Analytics",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Omni Analytics"
       },
@@ -44,7 +44,7 @@
       "name": "omni-integrations",
       "source": "./skills/omni-integrations",
       "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {
     "name": "Omni Analytics",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.3.0] - 2026-04-21
+
+### omni-analytics
+
+**Added**
+- Eval framework for all 9 Omni skills (`evals/` directory with runner, scorer, and per-skill `evals.json`)
+- Comprehensive `visConfig` reference doc for content builder
+- Validation loops to model-builder, admin, query, and content builder skills
+
+**Changed**
+- AI optimizer skill updated for AI topic optimization
+- Replaced CLI auto-install with check-and-prompt behavior across all skills
+- Updated skills to use CLI shorthand syntax
+- Rebranded AI assistant / query helper terminology
+
+**Fixed**
+- Clarified workbook model update flow in content builder
+- Fixed primary key guidance in model builder
+
+## [1.1.0] - 2026-04-21
+
+### omni-integrations
+
+**Added**
+- New `omni-to-databricks-metric-views` skill with field mapping and YAML reference docs
+- Cursor plugin support (`.cursor-plugin/`)
+
+**Changed**
+- Improved `omni-to-snowflake-semantic-view` skill with troubleshooting section and synonym support
+
 ## Unreleased
 
 No unreleased changes yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ The versions documented here should match the published plugin versions in the a
 - Eval framework for all 9 Omni skills (`evals/` directory with runner, scorer, and per-skill `evals.json`)
 - Comprehensive `visConfig` reference doc for content builder
 - Validation loops to model-builder, admin, query, and content builder skills
+- Migration note for users coming from deprecated repos
 
 **Changed**
 - AI optimizer skill updated for AI topic optimization
 - Replaced CLI auto-install with check-and-prompt behavior across all skills
 - Updated skills to use CLI shorthand syntax
 - Rebranded AI assistant / query helper terminology
+- Updated Omni Agent context and values
+- Removed `svgMap`, `code`, and `omni-spreadsheet` chart types from visConfig reference
 
 **Fixed**
 - Clarified workbook model update flow in content builder
@@ -35,6 +38,11 @@ The versions documented here should match the published plugin versions in the a
 
 **Changed**
 - Improved `omni-to-snowflake-semantic-view` skill with troubleshooting section and synonym support
+
+**Fixed**
+- Fixed Cursor integrations install (subdirectory URLs not supported)
+- Fixed critical rule for `comment` vs `description` field key in Databricks metric view definitions
+- Fixed synonym mapping from Omni fields into Databricks metric view definitions
 
 ## Unreleased
 

--- a/skills/omni-integrations/.claude-plugin/plugin.json
+++ b/skills/omni-integrations/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-integrations",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
   "author": {
     "name": "Omni Analytics",

--- a/skills/omni-integrations/.cursor-plugin/plugin.json
+++ b/skills/omni-integrations/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-integrations",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
   "author": {
     "name": "Omni Analytics",


### PR DESCRIPTION
## Summary

- Bumps `omni-analytics` from `1.2.0` → `1.3.0`
- Bumps `omni-integrations` from `1.0.0` → `1.1.0`
- Updates CHANGELOG.md with entries for both releases

## What's in these releases

**omni-analytics 1.3.0**
- Added eval framework for all 9 skills
- Added comprehensive `visConfig` reference doc for content builder
- Added validation loops to model-builder, admin, query, and content builder skills
- Updated AI optimizer skill for AI topic optimization
- Replaced CLI auto-install with check-and-prompt across all skills
- Fixed workbook model update flow and primary key guidance

**omni-integrations 1.1.0**
- Added `omni-to-databricks-metric-views` skill
- Added Cursor plugin support
- Improved `omni-to-snowflake-semantic-view` skill

## Test plan
- [ ] Verify plugin version numbers appear correctly after install/update in Claude Code and Cursor
- [ ] Confirm users reporting stale plugin versions can now pull the updated versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)