### PR TITLE
Fix views: wrapper in content builder yaml-create example

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {
     "name": "Omni Analytics",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {
     "name": "Omni Analytics",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.3.1] - 2026-04-21
+
+### omni-analytics
+
+**Fixed**
+- Removed invalid `views: <view_name>:` wrapper from content builder `yaml-create` example — the API rejects it with `saveError: "Invalid property name at \"views\""`. The YAML body must start directly at `dimensions:` / `measures:`.
+
 ## [1.3.0] - 2026-04-21
 
 ### omni-analytics

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -238,7 +238,7 @@ omni documents get <documentId>
 ```bash
 omni models yaml-create <workbookModelId> --body '{
   "fileName": "order_items.view",
-  "yaml": "views:\n  order_items:\n    dimensions:\n      is_high_value:\n        sql: \"${sale_price} > 100\"\n        label: High Value Order\n    measures:\n      high_value_count:\n        sql: \"${order_items.id}\"\n        aggregate_type: count_distinct\n        label: High Value Orders",
+  "yaml": "dimensions:\n  is_high_value:\n    sql: \"${sale_price} > 100\"\n    label: High Value Order\nmeasures:\n  high_value_count:\n    sql: \"${order_items.id}\"\n    aggregate_type: count_distinct\n    label: High Value Orders",
   "mode": "extension"
 }'
 ```


### PR DESCRIPTION
## Summary

Fixes the `yaml` body in the content builder's workbook model update example. The top-level `views: <view_name>:` wrapper was being included, which the API rejects with `saveError: "Invalid property name at \"views\""`.

The `fileName` field already tells the API which view the YAML targets — the body should start directly at `dimensions:` / `measures:`, consistent with how `omni-model-builder` formats it.

Bumps `omni-analytics` to `1.2.1` (patch).

Closes exploreomni/omni#48630

## Test plan
- [ ] Follow the updated Step 2 example and confirm `omni models yaml-create` succeeds without a `saveError`
- [ ] Confirm inherited fields from the shared base view remain intact after the write

🤖 Generated with [Claude Code](https://claude.com/claude-code)