### PR TITLE
Replace env-var auth with CLI profile workflow and add -o flag guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.2"
+    "version": "1.3.3"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.2",
+  "version": "1.3.3",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.2"
+    "version": "1.3.3"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.2",
+  "version": "1.3.3",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,10 @@ Before opening a PR, validate that your skill or agent works against a real Omni
 1. **Install the Omni CLI** if not already present — see [README Setup](README.md#setup)
 2. **Configure credentials**:
    ```bash
-   export OMNI_BASE_URL="https://yourorg.omniapp.co"
-   export OMNI_API_TOKEN="your-api-key"
+   # Show available profiles and select the appropriate one
+   omni config show
+   # If multiple profiles exist, pick one and switch:
+   omni config use <profile-name>
    ```
 3. **Run the key CLI commands** referenced in your skill — verify they succeed and return expected output
 4. **For query or model skills**: run at least one realistic end-to-end operation (e.g., `omni query run`, `omni models yaml-create`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.3.3] - 2026-04-23
+
+### omni-analytics
+
+**Changed**
+- Replaced env-var auth setup (`export OMNI_BASE_URL` / `export OMNI_API_TOKEN`) with CLI profile workflow (`omni config show` → `omni config use`) across all skills, README, AGENTS.md, and rules
+- Added `-o` / `--format` flag guidance to all skills for controlling JSON vs human-readable output
+
 ## [1.3.2] - 2026-04-22
 
 ### omni-analytics

--- a/README.md
+++ b/README.md
@@ -196,13 +196,13 @@ This downloads the latest release, verifies the SHA-256 checksum, and installs t
 ### Configure authentication
 
 ```bash
-# Option 1: Interactive profile setup (recommended)
-omni config init
-
-# Option 2: Environment variables
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, pick one and switch:
+omni config use <profile-name>
 ```
+
+If no profiles exist, run `omni config init` to create one interactively. You can also use `--profile`, `--base-url`, or `--token` flags to override the active profile for a single command.
 
 API keys are created in **Settings > API Keys** (Organization Admin) or **User Profile > Manage Account > Generate Token** (Personal Access Token).
 

--- a/rules/omni-api-conventions.mdc
+++ b/rules/omni-api-conventions.mdc
@@ -33,15 +33,18 @@ Two API key types exist:
 ### Setup
 
 ```bash
-# Option 1: Interactive profile setup (recommended, one-time)
-omni config init
-
-# Option 2: Environment variables
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
-Base URL is resolved in this order: `--base-url` flag > `OMNI_BASE_URL` env var > profile's `apiEndpoint`.
+If no profiles exist, run `omni config init` to create one interactively.
+
+Base URL and token are resolved in this order (highest wins):
+1. `--base-url` / `--token` flags on the command
+2. `OMNI_BASE_URL` / `OMNI_API_TOKEN` environment variables
+3. Active profile's `apiEndpoint` / `apiKey`
 
 ## Command Pattern
 
@@ -68,8 +71,9 @@ omni <group> <operation> --help    # Show flags and positional args
 
 ## Output
 
-- All responses are JSON to stdout (pretty-printed by default)
-- Use `--compact` for single-line JSON (good for piping to `jq`)
+- Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables.
+- The default is `-o auto` (human in a TTY, JSON when piped or redirected).
+- Use `--compact` for single-line JSON (good for piping to `jq`).
 - Errors go to stderr as JSON with `error` and `status` fields
 
 ## Error Handling

--- a/skills/omni-admin/SKILL.md
+++ b/skills/omni-admin/SKILL.md
@@ -18,8 +18,10 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
 ## Discovering Commands
@@ -31,6 +33,8 @@ omni connections --help      # Connection management
 omni documents --help        # Document permissions
 omni folders --help          # Folder permissions
 ```
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## Connections
 

--- a/skills/omni-ai-eval/SKILL.md
+++ b/skills/omni-ai-eval/SKILL.md
@@ -18,8 +18,10 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
 You also need a **model ID** and an **eval set** — a file of test cases with prompts and expected query structures. See the [Eval Design Guide](https://docs.omni.co/ai/eval-design-guide) for best practices on building eval sets.
@@ -29,6 +31,8 @@ You also need a **model ID** and an **eval set** — a file of test cases with p
 ```bash
 omni ai --help    # AI operations (generate-query, jobs, pick-topic)
 ```
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## Eval Input Format
 

--- a/skills/omni-ai-optimizer/SKILL.md
+++ b/skills/omni-ai-optimizer/SKILL.md
@@ -18,8 +18,10 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
 Requires **Modeler** or **Connection Admin** permissions.
@@ -30,6 +32,8 @@ Requires **Modeler** or **Connection Admin** permissions.
 omni models --help                    # List all model operations
 omni models yaml-create --help        # Show flags for writing YAML
 ```
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## How Blobby Works
 

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -27,8 +27,10 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
 ## Discovering Commands
@@ -38,6 +40,8 @@ omni documents --help           # Document operations
 omni dashboards --help          # Dashboard operations
 omni models yaml-create --help  # Writing model YAML
 ```
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## Dashboard Architecture
 
@@ -178,6 +182,7 @@ This returns the full document including `queryPresentations`, `filterConfig`, `
 ```bash
 # Note: Full document replacement via PUT is not yet available in the CLI.
 # Use direct HTTP for now, or use omni documents update for partial updates (PATCH).
+# Derive OMNI_BASE_URL and OMNI_API_TOKEN from the active profile for this call.
 curl -L -X PUT "$OMNI_BASE_URL/api/v1/documents/{documentId}" \
   -H "Authorization: Bearer $OMNI_API_TOKEN" \
   -H "Content-Type: application/json" \

--- a/skills/omni-content-explorer/SKILL.md
+++ b/skills/omni-content-explorer/SKILL.md
@@ -16,8 +16,10 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
 ## Discovering Commands
@@ -27,6 +29,8 @@ omni content --help     # Content operations
 omni documents --help   # Document operations
 omni folders --help     # Folder operations
 ```
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## Browsing Content
 

--- a/skills/omni-embed/SKILL.md
+++ b/skills/omni-embed/SKILL.md
@@ -22,8 +22,11 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
+
 export OMNI_EMBED_SECRET="your-embed-secret"   # Admin → Embed (for URL signing)
 ```
 
@@ -36,6 +39,8 @@ omni scim --help        # Embed user lookup
 omni documents --help   # Document listing
 omni folders --help     # Folder listing
 ```
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## Signing Embed URLs
 

--- a/skills/omni-integrations/skills/omni-to-databricks-metric-views/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-databricks-metric-views/SKILL.md
@@ -20,8 +20,10 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
 ```bash
@@ -31,6 +33,8 @@ cat ~/.databrickscfg
 ```
 
 ---
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## Workflow
 

--- a/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
@@ -18,11 +18,15 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
 ---
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## Runtime Environment Detection
 

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -18,11 +18,15 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
 You need **Modeler** or **Connection Admin** permissions.
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## Omni's Layered Modeling Architecture
 

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -20,8 +20,10 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
 API keys: Settings > API Keys (Organization Admin) or User Profile > Manage Account > Generate Token (Personal Access Token).
@@ -34,6 +36,8 @@ When unsure what operations or flags are available:
 omni models --help              # List all model operations
 omni models <operation> --help  # Show flags and positional args
 ```
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## Core Workflow
 

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -18,8 +18,10 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 ```
 
 ```bash
-export OMNI_BASE_URL="https://yourorg.omniapp.co"
-export OMNI_API_TOKEN="your-api-key"
+# Show available profiles and select the appropriate one
+omni config show
+# If multiple profiles exist, ask the user which to use, then switch:
+omni config use <profile-name>
 ```
 
 You also need a **model ID** and knowledge of available **topics and fields**.
@@ -31,6 +33,8 @@ omni query --help              # List query operations
 omni query run --help          # Show flags for running a query
 omni ai --help                 # AI-powered query generation
 ```
+
+> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
 
 ## Running a Query
 


### PR DESCRIPTION
## Summary

Replaces the outdated `export OMNI_BASE_URL` / `export OMNI_API_TOKEN` auth pattern across all skills with the modern CLI profile workflow (`omni config show` → `omni config use`). Also adds `-o json` / `-o human` output format guidance to every skill so agents know when to force structured output.

## Changes

- **11 skills**: Replaced env-var prerequisites with `omni config show` + `omni config use <profile>` workflow
- **11 skills**: Added `-o` / `--format` flag tip for controlling JSON vs human-readable output
- **README.md**: Updated auth setup section to recommend profiles
- **AGENTS.md**: Updated validation steps to use profile workflow
- **rules/omni-api-conventions.mdc**: Updated auth setup and output handling sections
- **Version bump**: `omni-analytics` 1.3.2 → 1.3.3 in all 4 plugin manifests
- **CHANGELOG.md**: Added 1.3.3 release notes

## Verification

- [x] All skill `description` fields unchanged — routing unaffected
- [x] No CLI flags hallucinated — all patterns verified against actual CLI behavior
- [x] Version bumped in all affected manifests