### PR TITLE
Document schema-aware lazy loading in model skills

### DIFF
--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -193,8 +193,11 @@ omni models get-topic <modelId> <topicName> --branch-id <branchId>
 omni models yaml-get <modelId> --filename your_view.view --branchid <branchId>
 
 # If you're working in a specific schema and want to avoid loading the full model,
-# use schema-scoped lazy loading (see omni-model-explorer § Schema-Aware Lazy Loading):
-omni models yaml-get <modelId> --includeschemas YOUR_SCHEMA --branchid <branchId>
+# use schema-scoped lazy loading via curl (see omni-model-explorer § Schema-Aware Lazy Loading).
+# The `includeSchemas` query param is not yet exposed in the CLI — tracked in
+# https://github.com/exploreomni/cli/issues/44.
+curl -H "Authorization: Bearer $OMNI_API_TOKEN" \
+  "$OMNI_BASE_URL/api/v1/models/<modelId>/yaml?includeSchemas=YOUR_SCHEMA&branchId=<branchId>"
 ```
 
 Confirm your new fields are listed in the response. If they're missing, the YAML write may have silently failed (e.g., wrong `fileName`, malformed YAML string).

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -191,6 +191,10 @@ omni models get-topic <modelId> <topicName> --branch-id <branchId>
 
 # Or read back the YAML you just wrote
 omni models yaml-get <modelId> --filename your_view.view --branchid <branchId>
+
+# If you're working in a specific schema and want to avoid loading the full model,
+# use schema-scoped lazy loading (see omni-model-explorer § Schema-Aware Lazy Loading):
+omni models yaml-get <modelId> --includeschemas YOUR_SCHEMA --branchid <branchId>
 ```
 
 Confirm your new fields are listed in the response. If they're missing, the YAML write may have silently failed (e.g., wrong `fileName`, malformed YAML string).

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -192,15 +192,9 @@ omni models get-topic <modelId> <topicName> --branch-id <branchId>
 # Or read back the YAML you just wrote
 omni models yaml-get <modelId> --filename your_view.view --branchid <branchId>
 
-# If you're working in a specific schema and want to avoid loading the full model,
-# use schema-scoped lazy loading via curl (see omni-model-explorer § Schema-Aware Lazy Loading).
-# The `includeSchemas` query param is not yet exposed in the CLI — tracked in
-# https://github.com/exploreomni/cli/issues/44.
-curl -H "Authorization: Bearer $OMNI_API_TOKEN" \
-  "$OMNI_BASE_URL/api/v1/models/<modelId>/yaml?includeSchemas=YOUR_SCHEMA&branchId=<branchId>"
 ```
 
-Confirm your new fields are listed in the response. If they're missing, the YAML write may have silently failed (e.g., wrong `fileName`, malformed YAML string).
+Confirm your new fields are listed in the response. If they're missing, the YAML write may have silently failed (e.g., wrong `fileName`, malformed YAML string) — or the view may live in an offloaded schema that `yaml-get` doesn't surface. See `omni-model-explorer` § Fallback: Expected View Missing from `yaml-get` for how to recover.
 
 ### Step 3: Merge the Branch
 

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -104,32 +104,6 @@ omni models yaml-get <modelId> --branchid <branchId>
 
 The `mode` parameter: `combined` (default) merges schema + shared model; `extension` shows only shared model customizations.
 
-### Step 4a: Schema-Aware Lazy Loading (large models)
-
-Large models with many schemas are slow to load in full. Use the two-step lazy-load pattern to fetch only what you need — this mirrors how the Omni IDE loads schemas on demand.
-
-**Rule: always list schemas before loading YAML when the model has multiple schemas or when your work is scoped to a specific schema.**
-
-> **Note**: These two endpoints are live on the API but not yet exposed in the Omni CLI (tracked in [exploreomni/cli#44](https://github.com/exploreomni/cli/issues/44)). Call them via `curl` until the CLI is updated. The examples below assume `OMNI_BASE_URL` and `OMNI_API_TOKEN` are exported — the CLI profile is not read by curl.
-
-```bash
-# 1. List all available schemas (includes inactive and offloaded schemas)
-curl -H "Authorization: Bearer $OMNI_API_TOKEN" \
-  "$OMNI_BASE_URL/api/v1/models/<modelId>/schemas"
-# → {"schemas": ["ANALYTICS", "PUBLIC", "STAGING"]}
-
-# 2. Load YAML for a single schema only
-curl -H "Authorization: Bearer $OMNI_API_TOKEN" \
-  "$OMNI_BASE_URL/api/v1/models/<modelId>/yaml?includeSchemas=PUBLIC"
-```
-
-**Rules for schema lazy loading:**
-- `includeSchemas` accepts exactly **one schema name** — commas are rejected. Load schemas one at a time.
-- The schemas list includes **inactive and offloaded** schemas — not just currently active ones. Check before deciding to load.
-- When `includeSchemas` is set, the response contains only views belonging to that schema. Relationships are preserved across schemas.
-- To scope to a branch, add `&branchId=<id>` to the yaml query or `?branch_id=<id>` to the schemas query (the API uses different casing per endpoint).
-- Prefer lazy loading over full `yaml-get` whenever your task is schema-specific — it is significantly faster and avoids unnecessary data transfer.
-
 ## Model Architecture
 
 Omni has three layers:
@@ -157,6 +131,34 @@ When exploring, use the `combined` view to see everything available.
 **"How do these tables relate?"** — Inspect the topic's `relationships[]` — check `join_from_view`, `join_to_view`, `on_sql`, and `relationship_type`.
 
 **"What measures are available for Y?"** — Inspect the topic containing view Y → review the `measures[]` array with `aggregate_type` and `sql` definitions.
+
+## Fallback: Expected View Missing from `yaml-get`
+
+Use this pattern only when normal exploration comes up short — the user names a specific view and it's absent from the `yaml-get` or `get-topic` response, or a relationship references a view that doesn't appear. If `yaml-get` returned what you expected, skip this section.
+
+**Why it happens:** `yaml-get` only returns views from currently-loaded schemas. If a schema is **offloaded or inactive**, its views won't show up. The `/schemas` endpoint surfaces *all* schemas the connection knows about — including offloaded and inactive ones — so it's the right next step before telling the user "not found."
+
+> **Note**: These endpoints aren't yet exposed in the Omni CLI (tracked in [exploreomni/cli#44](https://github.com/exploreomni/cli/issues/44)), so they're curl-only for now. Examples assume `OMNI_BASE_URL` and `OMNI_API_TOKEN` are exported — curl does not read the CLI profile.
+
+**Two-step recovery:**
+
+```bash
+# 1. List every schema (loaded, offloaded, and inactive)
+curl -H "Authorization: Bearer $OMNI_API_TOKEN" \
+  "$OMNI_BASE_URL/api/v1/models/<modelId>/schemas"
+# → {"schemas": ["ANALYTICS", "PUBLIC", "STAGING", ...]}
+
+# 2. If the target schema is in the list, load just that schema
+curl -H "Authorization: Bearer $OMNI_API_TOKEN" \
+  "$OMNI_BASE_URL/api/v1/models/<modelId>/yaml?includeSchemas=PUBLIC"
+```
+
+**If the schema isn't in the list at all**, this isn't a lazy-load issue — the connection likely doesn't have access or the schema isn't synced. Check with a Connection Admin.
+
+**Rules for `includeSchemas`:**
+- Accepts exactly **one schema name** — commas are rejected. Load schemas one at a time if you need multiple.
+- When set, the response contains only views belonging to that schema. Relationships are preserved even when they reference views in other schemas.
+- To scope to a branch, add `&branchId=<id>` to the yaml query or `?branch_id=<id>` to the schemas query (the API uses different casing per endpoint).
 
 ## Calculation Fields
 

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -104,6 +104,28 @@ omni models yaml-get <modelId> --branchid <branchId>
 
 The `mode` parameter: `combined` (default) merges schema + shared model; `extension` shows only shared model customizations.
 
+### Step 4a: Schema-Aware Lazy Loading (large models)
+
+Large models with many schemas are slow to load in full. Use the two-step lazy-load pattern to fetch only what you need — this mirrors how the Omni IDE loads schemas on demand.
+
+**Rule: always list schemas before loading YAML when the model has multiple schemas or when your work is scoped to a specific schema.**
+
+```bash
+# 1. List all available schemas (includes inactive and offloaded schemas)
+omni models get-schemas <modelId>
+# → {"schemas": ["ANALYTICS", "PUBLIC", "STAGING"]}
+
+# 2. Load YAML for a single schema only
+omni models yaml-get <modelId> --includeschemas PUBLIC
+```
+
+**Rules for schema lazy loading:**
+- `--includeschemas` accepts exactly **one schema name** — commas are rejected. Load schemas one at a time.
+- The schemas list includes **inactive and offloaded** schemas — not just currently active ones. Check before deciding to load.
+- When `--includeschemas` is set, the response contains only views belonging to that schema. Relationships are preserved across schemas.
+- Use `--branchid` on `yaml-get` or `--branch-id` on `get-schemas` to inspect in-progress model changes (flag spelling follows each endpoint's underlying query param).
+- Prefer lazy loading over full `yaml-get` whenever your task is schema-specific — it is significantly faster and avoids unnecessary data transfer.
+
 ## Model Architecture
 
 Omni has three layers:
@@ -164,6 +186,7 @@ Search the response for the field name to find references in other views, topics
 ## Docs Reference
 
 - [Models API](https://docs.omni.co/api/models.md) · [Topics API](https://docs.omni.co/api/topics.md) · [Modeling Overview](https://docs.omni.co/modeling.md) · [Views](https://docs.omni.co/modeling/views.md) · [Topics](https://docs.omni.co/modeling/topics/parameters.md) · [Dimensions](https://docs.omni.co/modeling/dimensions.md) · [Measures](https://docs.omni.co/modeling/measures.md)
+- [List model schemas](https://docs.omni.co/api/models/list-model-schemas) · [Get model YAML](https://docs.omni.co/api/models/get-model-yaml)
 
 ## Related Skills
 

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -110,20 +110,24 @@ Large models with many schemas are slow to load in full. Use the two-step lazy-l
 
 **Rule: always list schemas before loading YAML when the model has multiple schemas or when your work is scoped to a specific schema.**
 
+> **Note**: These two endpoints are live on the API but not yet exposed in the Omni CLI (tracked in [exploreomni/cli#44](https://github.com/exploreomni/cli/issues/44)). Call them via `curl` until the CLI is updated. The examples below assume `OMNI_BASE_URL` and `OMNI_API_TOKEN` are exported — the CLI profile is not read by curl.
+
 ```bash
 # 1. List all available schemas (includes inactive and offloaded schemas)
-omni models get-schemas <modelId>
+curl -H "Authorization: Bearer $OMNI_API_TOKEN" \
+  "$OMNI_BASE_URL/api/v1/models/<modelId>/schemas"
 # → {"schemas": ["ANALYTICS", "PUBLIC", "STAGING"]}
 
 # 2. Load YAML for a single schema only
-omni models yaml-get <modelId> --includeschemas PUBLIC
+curl -H "Authorization: Bearer $OMNI_API_TOKEN" \
+  "$OMNI_BASE_URL/api/v1/models/<modelId>/yaml?includeSchemas=PUBLIC"
 ```
 
 **Rules for schema lazy loading:**
-- `--includeschemas` accepts exactly **one schema name** — commas are rejected. Load schemas one at a time.
+- `includeSchemas` accepts exactly **one schema name** — commas are rejected. Load schemas one at a time.
 - The schemas list includes **inactive and offloaded** schemas — not just currently active ones. Check before deciding to load.
-- When `--includeschemas` is set, the response contains only views belonging to that schema. Relationships are preserved across schemas.
-- Use `--branchid` on `yaml-get` or `--branch-id` on `get-schemas` to inspect in-progress model changes (flag spelling follows each endpoint's underlying query param).
+- When `includeSchemas` is set, the response contains only views belonging to that schema. Relationships are preserved across schemas.
+- To scope to a branch, add `&branchId=<id>` to the yaml query or `?branch_id=<id>` to the schemas query (the API uses different casing per endpoint).
 - Prefer lazy loading over full `yaml-get` whenever your task is schema-specific — it is significantly faster and avoids unnecessary data transfer.
 
 ## Model Architecture


### PR DESCRIPTION
## Summary

Documents the schema-aware lazy-load API pattern in `omni-model-explorer` and `omni-model-builder`, framed as a **fallback for when a view is missing from normal exploration** rather than a default optimization.

### Two endpoints (curl-only until [exploreomni/cli#44](https://github.com/exploreomni/cli/issues/44) ships)

- `GET /api/v1/models/{modelId}/schemas` — lists **all** schemas including inactive and offloaded ones
- `GET /api/v1/models/{modelId}/yaml?includeSchemas=<schema>` — scopes YAML to one schema's views (relationships preserved)

### What changed

**`omni-model-explorer`**: Added a `Fallback: Expected View Missing from yaml-get` section (after Exploration Patterns, not in Core Workflow). Framing: use this only when normal `yaml-get` or `get-topic` doesn't surface a view the user named. Root cause explained — `yaml-get` skips offloaded/inactive schemas; `/schemas` surfaces all of them. Includes recovery steps and what to do if the schema isn't in the list at all.

**`omni-model-builder`**: Removed the `curl … includeSchemas` snippet from Step 2d. Extended the "if your field is missing" note to point at the new fallback section.

**Removed**: the `Step 4a: Schema-Aware Lazy Loading` sub-step and the "always list schemas first" rule — both implied the pattern was a default, which the agent can't apply without already knowing the model size.

### Rules captured
- `includeSchemas` accepts **one schema name** per call — commas rejected
- Schemas list includes **inactive and offloaded** schemas, not just active ones
- Relationships are preserved even when the response is scoped to one schema
- Branch casing differs per endpoint: `&branchId=` on yaml, `?branch_id=` on schemas

### Tested end-to-end
Verified the full fallback flow on a real model (100+ schemas):
- `yaml-get` returned nothing for `SNOWFLAKE.ORGANIZATION_USAGE/usage_in_currency_daily.view` (offloaded schema)
- `/schemas` surfaced it in the list
- `/yaml?includeSchemas=SNOWFLAKE.ORGANIZATION_USAGE` returned the view
- Added a `dracul_mihawk` count measure on a branch — verified via scoped curl

Underlying API: [exploreomni/omni#48383](https://github.com/exploreomni/omni/pull/48383) (merged).

## Test plan
- [x] Fallback workflow verified end-to-end on a real offloaded schema
- [x] Trigger condition is concrete and agent-recognizable ("user named a view, it's not in yaml-get")
- [ ] Skill ergonomics reviewed by maintainers
- [ ] Swap curl → CLI after [exploreomni/cli#44](https://github.com/exploreomni/cli/issues/44) ships (separate follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)