### PR TITLE
Add schema-aware lazy-load fallback using new CLI commands (1.3.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.3"
+    "version": "1.3.4"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.3",
+  "version": "1.3.4",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.3"
+    "version": "1.3.4"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.3",
+  "version": "1.3.4",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ The versions documented here should match the published plugin versions in the a
 
 ### omni-analytics
 
-**Changed**
-- Swapped `curl` calls in the schema-aware lazy-load fallback (omni-model-explorer § Fallback: Expected View Missing from `yaml-get`) for the new first-class CLI commands (`omni models get-schemas` and `omni models yaml-get --includeschemas`), shipped in [exploreomni/cli#46](https://github.com/exploreomni/cli/pull/46). Removes the need to export `OMNI_BASE_URL` / `OMNI_API_TOKEN` for this path — the CLI reads from the active profile.
-- Documented the asymmetric branch-scoping flag names: `yaml-get` uses `--branchid`, `get-schemas` uses `--branch-id` (the CLI is auto-generated from the API spec, which uses different casing per endpoint).
+**Added**
+- Schema-aware lazy-load fallback pattern in omni-model-explorer § Fallback: Expected View Missing from `yaml-get`. When normal exploration can't find a view the user named, it's likely in an offloaded or inactive schema. Fallback uses `omni models get-schemas <modelId>` to surface all schemas (including offloaded/inactive) and `omni models yaml-get <modelId> --includeschemas <schema>` to load views from one of them. Requires CLI commands shipped in [exploreomni/cli#46](https://github.com/exploreomni/cli/pull/46).
 
 ## [1.3.3] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The versions documented here should match the published plugin versions in the a
 ### omni-analytics
 
 **Added**
-- Schema-aware lazy-load fallback pattern in omni-model-explorer § Fallback: Expected View Missing from `yaml-get`. When normal exploration can't find a view the user named, it's likely in an offloaded or inactive schema. Fallback uses `omni models get-schemas <modelId>` to surface all schemas (including offloaded/inactive) and `omni models yaml-get <modelId> --includeschemas <schema>` to load views from one of them. Requires CLI commands shipped in [exploreomni/cli#46](https://github.com/exploreomni/cli/pull/46).
+- Schema-aware lazy-load fallback pattern in omni-model-explorer § Fallback: Expected View Missing from `yaml-get`. When normal exploration can't find a view the user named, it's likely in an offloaded or inactive schema. Fallback uses `omni models get-schemas <modelId>` to surface all schemas (including offloaded/inactive) and `omni models yaml-get <modelId> --includeschemas <schema>` to load views from one of them.
 
 ## [1.3.3] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.3.4] - 2026-04-24
+
+### omni-analytics
+
+**Changed**
+- Swapped `curl` calls in the schema-aware lazy-load fallback (omni-model-explorer § Fallback: Expected View Missing from `yaml-get`) for the new first-class CLI commands (`omni models get-schemas` and `omni models yaml-get --includeschemas`), shipped in [exploreomni/cli#46](https://github.com/exploreomni/cli/pull/46). Removes the need to export `OMNI_BASE_URL` / `OMNI_API_TOKEN` for this path — the CLI reads from the active profile.
+- Documented the asymmetric branch-scoping flag names: `yaml-get` uses `--branchid`, `get-schemas` uses `--branch-id` (the CLI is auto-generated from the API spec, which uses different casing per endpoint).
+
 ## [1.3.3] - 2026-04-23
 
 ### omni-analytics

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -136,29 +136,25 @@ When exploring, use the `combined` view to see everything available.
 
 Use this pattern only when normal exploration comes up short — the user names a specific view and it's absent from the `yaml-get` or `get-topic` response, or a relationship references a view that doesn't appear. If `yaml-get` returned what you expected, skip this section.
 
-**Why it happens:** `yaml-get` only returns views from currently-loaded schemas. If a schema is **offloaded or inactive**, its views won't show up. The `/schemas` endpoint surfaces *all* schemas the connection knows about — including offloaded and inactive ones — so it's the right next step before telling the user "not found."
-
-> **Note**: These endpoints aren't yet exposed in the Omni CLI (tracked in [exploreomni/cli#44](https://github.com/exploreomni/cli/issues/44)), so they're curl-only for now. Examples assume `OMNI_BASE_URL` and `OMNI_API_TOKEN` are exported — curl does not read the CLI profile.
+**Why it happens:** `yaml-get` only returns views from currently-loaded schemas. If a schema is **offloaded or inactive**, its views won't show up. The `get-schemas` call surfaces *all* schemas the connection knows about — including offloaded and inactive ones — so it's the right next step before telling the user "not found."
 
 **Two-step recovery:**
 
 ```bash
 # 1. List every schema (loaded, offloaded, and inactive)
-curl -H "Authorization: Bearer $OMNI_API_TOKEN" \
-  "$OMNI_BASE_URL/api/v1/models/<modelId>/schemas"
+omni models get-schemas <modelId>
 # → {"schemas": ["ANALYTICS", "PUBLIC", "STAGING", ...]}
 
 # 2. If the target schema is in the list, load just that schema
-curl -H "Authorization: Bearer $OMNI_API_TOKEN" \
-  "$OMNI_BASE_URL/api/v1/models/<modelId>/yaml?includeSchemas=PUBLIC"
+omni models yaml-get <modelId> --includeschemas PUBLIC
 ```
 
 **If the schema isn't in the list at all**, this isn't a lazy-load issue — the connection likely doesn't have access or the schema isn't synced. Check with a Connection Admin.
 
-**Rules for `includeSchemas`:**
-- Accepts exactly **one schema name** — commas are rejected. Load schemas one at a time if you need multiple.
+**Rules for `--includeschemas`:**
+- Accepts exactly **one schema name** per call — commas are rejected by the API. Load schemas one at a time if you need multiple.
 - When set, the response contains only views belonging to that schema. Relationships are preserved even when they reference views in other schemas.
-- To scope to a branch, add `&branchId=<id>` to the yaml query or `?branch_id=<id>` to the schemas query (the API uses different casing per endpoint).
+- To scope to a branch, add `--branchid <id>` to `yaml-get` or `--branch-id <id>` to `get-schemas` (the flag names differ per command — this matches the API's underlying casing).
 
 ## Calculation Fields
 


### PR DESCRIPTION
## Summary

Adds a schema-aware lazy-load fallback pattern to `omni-model-explorer` for the case where normal exploration can't find a view the user named. Uses the first-class CLI commands shipped in [exploreomni/cli#46](https://github.com/exploreomni/cli/pull/46). Bumps the plugin to **1.3.4**.

## The problem

`yaml-get` only returns views from currently-loaded schemas. If a schema is **offloaded or inactive**, its views silently don't appear — the agent sees an empty response and reports "not found" when the view actually exists.

## The fallback

When normal `yaml-get --filename` or `get-topic` comes up short:

```bash
# 1. List every schema (loaded, offloaded, and inactive)
omni models get-schemas <modelId>

# 2. If the target schema is in the list, load just that schema
omni models yaml-get <modelId> --includeschemas <schema>
```

Positioned as a recovery path, not the default. The normal flow (`yaml-get --filename`, `get-topic`) resolves most requests in one call and should stay the primary route.

## Version bumps (`1.3.3` → `1.3.4`)
- `.claude-plugin/plugin.json` · `.claude-plugin/marketplace.json`
- `.cursor-plugin/plugin.json` · `.cursor-plugin/marketplace.json`
- `CHANGELOG.md`

## Verified end-to-end

Against a real 107-schema model (59 active, 48 offloaded):
- `yaml-get --filename '.*snowflake_prospects.*'` → 0 matches (offloaded)
- `get-schemas` → surfaces `BLUEBIRDS`
- `yaml-get --includeschemas BLUEBIRDS` → loads the 3 views
- Created a branch, wrote a `dracula` count measure, verified via `yaml-get --includeschemas BLUEBIRDS --branchid <id>`

## Test plan
- [x] CLI commands verified on a real model
- [x] Fallback workflow exercised end-to-end against an offloaded schema
- [x] All four manifest files bumped to 1.3.4
- [x] CHANGELOG entry added
- [ ] Maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)