### PR TITLE
fix(omni-model-builder): improve filter config guidance for topics and measures

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.4"
+    "version": "1.3.5"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.4",
+  "version": "1.3.5",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.4"
+    "version": "1.3.5"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.4",
+  "version": "1.3.5",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.3.5] - 2026-04-29
+
+### omni-analytics
+
+**Fixed**
+- Expanded topic key elements in omni-model-builder to include all four always-filter variants (`always_where_sql`, `always_where_filters`, `always_having_sql`, `always_having_filters`) with clear distinction between SQL expression and filter specification forms
+- Replaced incomplete 7-item measure filter condition list with a pointer to the new `yaml-filter-syntax.md` reference (which includes `greater_than_or_equal_to`, `less_than_or_equal_to`, negation, array values, boolean handling, and date/time operators)
+- Added guidance to use `omni ai search-omni-docs` when filter configuration for topics is unclear
+
+**Added**
+- `skills/omni-model-builder/references/yaml-filter-syntax.md` — comprehensive YAML filter operator reference covering all operator categories (conditional, numeric, string, date/time), negation, array values, boolean three-state logic, and field qualification rules for topic vs. measure context
+
 ## [1.3.4] - 2026-04-24
 
 ### omni-analytics

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -316,7 +316,7 @@ measures:
         is: California
 ```
 
-Filter conditions: `is`, `is_not`, `greater_than`, `less_than`, `contains`, `starts_with`, `ends_with`
+See `references/yaml-filter-syntax.md` for the complete operator reference covering conditional, numeric, string, and date/time operators, negation, array values, and boolean handling.
 
 ## Writing Topics
 
@@ -327,8 +327,23 @@ Key topic elements:
 - `joins` — nested structure for join chains (e.g., `users: {}` or `inventory_items: { products: {} }`)
 - `ai_context` — guides Blobby's field mapping (e.g., "Map 'revenue' → total_revenue")
 - `default_filters` — applied to all queries unless removed
-- `always_where_sql` — non-removable filters
+- `always_where_sql` — non-removable WHERE filter using a SQL expression (cannot be removed by users)
+- `always_where_filters` — non-removable WHERE filter using filter specifications (cannot be removed by users)
+- `always_having_sql` — non-removable HAVING filter using a SQL expression, applied after aggregation (cannot be removed by users)
+- `always_having_filters` — non-removable HAVING filter using filter specifications, applied after aggregation (cannot be removed by users)
 - `fields` — field curation: `[order_items.*, users.name, -users.internal_id]`
+
+### Filter Expressions for Topics
+
+When configuring `default_filters`, `always_where_filters`, or `always_having_filters` on a topic, use the YAML filter condition syntax — the same syntax used in measure filters. See `references/yaml-filter-syntax.md` for the complete reference.
+
+If the right filter configuration for a given use case isn't obvious, use the Omni AI CLI to search the docs:
+
+```bash
+omni ai search-omni-docs "how do I configure always_where_filters on a topic in Omni?"
+```
+
+Use targeted questions to get precise YAML examples for your specific filtering need before writing the model YAML.
 
 ## Writing Relationships
 

--- a/skills/omni-model-builder/references/yaml-filter-syntax.md
+++ b/skills/omni-model-builder/references/yaml-filter-syntax.md
@@ -13,11 +13,13 @@ Complete reference for the filter condition syntax used in Omni model YAML. This
   <operator>: <value>
 ```
 
-For topic-level filters, qualify field names with the view name:
+For topic-level filters, field names must be fully qualified (`view_name.field_name`) when referencing a field from a joined view. Fields on the topic's base view may use the bare field name:
 
 ```yaml
 always_where_filters:
-  users.state:
+  state:           # bare — field is on the base view
+    is: California
+  users.state:     # qualified — field is on a joined view
     is: California
 ```
 

--- a/skills/omni-model-builder/references/yaml-filter-syntax.md
+++ b/skills/omni-model-builder/references/yaml-filter-syntax.md
@@ -13,25 +13,25 @@ Complete reference for the filter condition syntax used in Omni model YAML. This
   <operator>: <value>
 ```
 
-For topic-level filters, field names must be fully qualified (`view_name.field_name`) when referencing a field from a joined view. Fields on the topic's base view may use the bare field name:
+For topic-level filters, always use fully qualified field names (`view_name.field_name`):
 
 ```yaml
 always_where_filters:
-  state:           # bare — field is on the base view
-    is: California
-  users.state:     # qualified — field is on a joined view
+  users.state:
     is: California
 ```
 
-For measure filters, use the bare field name (the field is already scoped to the view):
+For measure filters, use the bare field name for fields on the measure's own view. Fields from a joined view must be fully qualified:
 
 ```yaml
 measures:
   california_revenue:
     aggregate_type: sum
     filters:
-      state:
+      state:             # bare — field is on this view
         is: California
+      users.country:     # qualified — field is on a joined view
+        is: US
 ```
 
 ## Value Formats

--- a/skills/omni-model-builder/references/yaml-filter-syntax.md
+++ b/skills/omni-model-builder/references/yaml-filter-syntax.md
@@ -1,0 +1,216 @@
+# YAML Filter Syntax Reference
+
+Complete reference for the filter condition syntax used in Omni model YAML. This syntax applies across three contexts:
+
+- **Measure filters** — `filters:` block on a measure definition
+- **Topic always filters** — `always_where_filters:`, `always_having_filters:` on a topic
+- **Topic default filters** — `default_filters:` on a topic
+
+## Core Structure
+
+```yaml
+<field_name>:
+  <operator>: <value>
+```
+
+For topic-level filters, qualify field names with the view name:
+
+```yaml
+always_where_filters:
+  users.state:
+    is: California
+```
+
+For measure filters, use the bare field name (the field is already scoped to the view):
+
+```yaml
+measures:
+  california_revenue:
+    aggregate_type: sum
+    filters:
+      state:
+        is: California
+```
+
+## Value Formats
+
+**Strings and dates** — unquoted:
+```yaml
+contains: Blob
+before: 2025-01-01
+```
+
+**Arrays** — square bracket syntax:
+```yaml
+is: [ California, Oregon, Washington ]
+between: [ 10, 100 ]
+```
+
+**Booleans** — three-state logic:
+- `true` — true only
+- `false` — false only
+- `null` — null only
+- `falsey` — false or null
+
+## Negation
+
+Prefix any operator with `not_` to negate it:
+```yaml
+not_contains: test
+not_starts_with: internal
+not_between: [ 10, 100 ]
+```
+
+**Exceptions:** `and`, `or`, and `is` do not support `not_` prefix. Use the `not` operator instead of `not_is`:
+```yaml
+not: California
+```
+
+## Combining Multiple Conditions
+
+Multiple field conditions are AND-combined:
+```yaml
+filters:
+  state:
+    is: California
+  age:
+    greater_than_or_equal_to: 65
+```
+
+Use `and` / `or` for multiple conditions on the same field:
+```yaml
+filters:
+  status:
+    or:
+      - is: complete
+      - is: shipped
+```
+
+---
+
+## Conditional Operators
+
+| Operator | Description |
+|----------|-------------|
+| `is` | Exact match |
+| `not` | Does not match (use instead of `not_is`) |
+| `and` | Rows meeting all specified conditions |
+| `or` | Rows meeting at least one condition |
+
+## Numeric Operators
+
+| Operator | Description |
+|----------|-------------|
+| `greater_than` | `> N` |
+| `greater_than_or_equal_to` | `>= N` |
+| `less_than` | `< N` |
+| `less_than_or_equal_to` | `<= N` |
+| `between` | Inclusive range — value is `[ min, max ]` |
+
+### Examples
+
+```yaml
+amount:
+  greater_than_or_equal_to: 100
+```
+
+```yaml
+sale_price:
+  between: [ 50, 200 ]
+```
+
+## String Operators
+
+| Operator | Description |
+|----------|-------------|
+| `contains` | Contains substring |
+| `starts_with` | Starts with substring |
+| `ends_with` | Ends with substring |
+| `case_insensitive` | Modifier — makes other string operators case-insensitive |
+
+### Examples
+
+```yaml
+name:
+  contains: Smith
+```
+
+```yaml
+email:
+  not_ends_with: .test
+```
+
+## Date & Time Operators
+
+| Operator | Description |
+|----------|-------------|
+| `before` | Dates before a specified date |
+| `on_or_after` | Dates on or after a specified date |
+| `between_dates` | Dates within a range |
+| `time_for_duration` | Duration starting from a point in time |
+| `date_offset_from_query` | Dynamic date relative to workbook query parameters |
+| `day_of_week` | Specific day of week |
+| `day_of_month` | Specific day of month |
+| `day_of_quarter` | Specific day of quarter |
+| `day_of_year` | Specific day of year |
+| `hour_of_day` | Specific hour of day |
+| `month_of_year` | Specific month of year |
+| `quarter_of_year` | Specific quarter of year |
+
+### Examples
+
+```yaml
+# On or after a fixed date
+created_at:
+  on_or_after: 2024-01-01
+```
+
+```yaml
+# Date range (end date is exclusive)
+created_at:
+  between_dates: [ 2024-01-01, 2024-12-31 ]
+```
+
+```yaml
+# Before a fixed date
+created_at:
+  before: 2024-01-01
+```
+
+```yaml
+# Past 7 days (rolling)
+created_at:
+  time_for_duration: [ 7 days ago, 7 days ]
+```
+
+```yaml
+# Past 7 complete days
+created_at:
+  time_for_duration: [ 7 complete days ago, 7 days ]
+```
+
+```yaml
+# Duration from a fixed start date
+created_at:
+  time_for_duration: [ 2024-01-01, 3 months ]
+```
+
+```yaml
+# Specific day of week (negated)
+created_at:
+  not_day_of_week: Saturday
+```
+
+```yaml
+# Specific hour of day (1 = 1:00–1:59 AM)
+created_at:
+  hour_of_day: 1
+```
+
+## Advanced Operators
+
+| Operator | Description |
+|----------|-------------|
+| `cancel_query_filter` | Allows a measure to override user query filters with measure-specific values |
+| `field_name_in_query` | Filters using results of another query — includes only matching rows |
+| `field_name_not_in_query` | Inverse — excludes rows present in the filtering query |


### PR DESCRIPTION
## Summary

- Adds `references/yaml-filter-syntax.md` — a comprehensive YAML filter operator reference covering all categories (conditional, numeric, string, date/time), negation, array values, and boolean handling, sourced from the Omni filter docs
- Updates the Topics section to document all four always-filter variants (`always_where_sql`, `always_where_filters`, `always_having_sql`, `always_having_filters`) with clear SQL expression vs. filter specification distinction
- Replaces the incomplete 7-item filter condition list in the measure filters section with a pointer to the new reference
- Adds a directive to use `omni ai search-omni-docs` when filter configuration is unclear

## Test plan

- [ ] Verify `yaml-filter-syntax.md` operator list is consistent with https://docs.omni.co/modeling/filters/operators
- [ ] Confirm Topics section in SKILL.md correctly distinguishes `_sql` vs `_filters` variants
- [ ] Confirm measure filters section points to new reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)