### PR TITLE
fix(omni-model-builder): embed lazy-load fallback pattern for missing views

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.5"
+    "version": "1.3.6"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.5",
+  "version": "1.3.6",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.5"
+    "version": "1.3.6"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.5",
+  "version": "1.3.6",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.3.6] - 2026-05-01
+
+### omni-analytics
+
+**Fixed**
+- Embedded the lazy-load fallback pattern directly in omni-model-builder rather than cross-referencing omni-model-explorer. Adds a dedicated "Fallback: View Missing from yaml-get" section with the full two-step recovery commands (`get-schemas` + `yaml-get --includeschemas`), and a pre-flight directive in Writing Topics to run the fallback before concluding a view doesn't exist.
+
 ## [1.3.5] - 2026-04-29
 
 ### omni-analytics

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -194,7 +194,7 @@ omni models yaml-get <modelId> --filename your_view.view --branchid <branchId>
 
 ```
 
-Confirm your new fields are listed in the response. If they're missing, the YAML write may have silently failed (e.g., wrong `fileName`, malformed YAML string) — or the view may live in an offloaded schema that `yaml-get` doesn't surface. See `omni-model-explorer` § Fallback: Expected View Missing from `yaml-get` for how to recover.
+Confirm your new fields are listed in the response. If they're missing, the YAML write may have silently failed (e.g., wrong `fileName`, malformed YAML string) — or the view may live in an offloaded schema that `yaml-get` doesn't surface. Before concluding a view doesn't exist, run the lazy-load fallback (see "Fallback: View Missing from yaml-get" below).
 
 ### Step 3: Merge the Branch
 
@@ -318,7 +318,29 @@ measures:
 
 See `references/yaml-filter-syntax.md` for the complete operator reference covering conditional, numeric, string, and date/time operators, negation, array values, and boolean handling.
 
+## Fallback: View Missing from yaml-get
+
+Before concluding that a view doesn't exist, always run this two-step check. `yaml-get` only returns views from currently-loaded schemas — views in offloaded or inactive schemas won't appear, but they're still available.
+
+```bash
+# 1. List all schemas the connection knows about (loaded, offloaded, and inactive)
+omni models get-schemas <modelId>
+# → {"schemas": ["ANALYTICS", "PUBLIC", "STAGING", ...]}
+
+# 2. If the target schema appears in the list, load it explicitly
+omni models yaml-get <modelId> --includeschemas PUBLIC
+```
+
+**Rules for `--includeschemas`:**
+- Accepts exactly **one schema name** per call — commas are rejected. Load schemas one at a time.
+- The response will contain only views from that schema; relationships to other schemas are preserved.
+- To scope to a branch, add `--branchid <id>` to `yaml-get` or `--branch-id <id>` to `get-schemas` (flag names differ per command).
+
+If the schema isn't in the `get-schemas` list at all, the connection likely doesn't have access or the schema isn't synced — check with a Connection Admin.
+
 ## Writing Topics
+
+> **Before writing a topic, verify all views you plan to reference actually exist.** Run `omni models yaml-get <modelId>` and confirm each view appears. If a view is missing, run the lazy-load fallback above before concluding it doesn't exist — it may simply be in an offloaded schema.
 
 See [Topics setup](https://docs.omni.co/modeling/topics/setup.md) for complete YAML examples with joins, fields, and ai_context, and [Topic parameters](https://docs.omni.co/modeling/topics/parameters.md) for all available options.
 


### PR DESCRIPTION
## Summary

- Adds a dedicated "Fallback: View Missing from yaml-get" section directly in omni-model-builder with the full two-step recovery commands (`omni models get-schemas` + `omni models yaml-get --includeschemas`) — previously this was only a cross-reference to omni-model-explorer, which agents don't follow mid-task
- Replaces the weak cross-reference at line 197 with a forward pointer to the new section
- Adds a pre-flight verification directive to the Writing Topics section instructing the agent to confirm all views exist before writing, and to run the fallback before concluding a view doesn't exist
- Bumps to 1.3.6

## Test plan

- [ ] Attempt to build a topic referencing a view in an offloaded schema — agent should run `get-schemas` + `yaml-get --includeschemas` before reporting the view as missing
- [ ] Verify the fallback section appears correctly in the skill and commands match the CLI flag conventions (`--branchid` for `yaml-get`, `--branch-id` for `get-schemas`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)