### PR TITLE
docs: warn yaml-create fileName is an exact path (silent create-on-miss) + trim builder to ~500 lines

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.8"
+    "version": "1.3.9"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.3.8",
+  "version": "1.3.9",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.3.8"
+    "version": "1.3.9"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "omni-analytics",
 
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {
     "name": "Omni Analytics",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.3.9] - 2026-05-20
+
+### omni-analytics
+
+**Fixed**
+- Documented that `omni models yaml-create` treats `fileName` as an exact path identity (not a regex, unlike `yaml-get`): a non-matching name silently creates a new file at the repo root and still returns `success: true`, producing a duplicate view instead of editing the intended one. The `omni-model-builder` write step now instructs reusing the full-path key from the read response verbatim (incl. folder prefixes), adds a post-write anti-duplicate read-back check, and a Common Validation Errors row. `omni-model-explorer` now documents that the `files` map is keyed by full stored path.
+
+**Changed**
+- Trimmed redundancy in `omni-model-builder` (overlapping schema-refresh/troubleshooting content, duplicated layering prose, bullet lists) to keep the skill near the ~500-line length guidance. No behavior change.
+
 ## [1.3.8] - 2026-05-05
 
 ### omni-analytics

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -24,9 +24,7 @@ omni config show
 omni config use <profile-name>
 ```
 
-You need **Modeler** or **Connection Admin** permissions.
-
-> **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).
+You need **Modeler** or **Connection Admin** permissions. Add `-o json` to any command to force structured output for parsing (default `auto` is human in a TTY, JSON when piped).
 
 ## Omni's Layered Modeling Architecture
 
@@ -37,9 +35,7 @@ Omni uses a **layered approach** where each layer builds on top of the previous:
 3. **Workbook Model Layer** — Ad hoc extensions within individual workbooks. Used for experimental fields before promotion to shared model.
 4. **Branch Layer** — Intermediate development layer. Used when working in branches before merging changes to shared model.
 
-**Key concept**: The schema layer is the foundation and source of truth for table/column structure. When your database schema changes (new tables, deleted columns, type changes), you refresh the schema to keep Omni in sync. All user-created content (dimensions, measures, relationships, topics) flows through the shared model layer.
-
-**Development workflow**: When building or modifying the model, you work in **branches** (see "Safe Development Workflow" below). Branches are isolated copies where you can safely experiment before merging changes back to shared model. This skill covers creating and editing model definitions in both branches and shared models.
+**Key concept**: The schema layer is the source of truth for table/column structure (refreshed when the database changes); all user-created content (dimensions, measures, relationships, topics) flows through the shared model layer. You build and modify it in **branches** (see "Safe Development Workflow" below) before merging back to the shared model.
 
 ## Determine SQL Dialect
 
@@ -61,11 +57,7 @@ Use dialect-appropriate functions in your SQL (e.g. `SAFE_DIVIDE` for BigQuery, 
 
 The **schema layer** is auto-generated from your database. When your database schema changes (new/deleted/renamed columns, type changes), refresh Omni's schema layer to stay in sync.
 
-**When to trigger:**
-- New tables added to your database
-- Column added, renamed, or deleted in an existing table
-- Creating a new view from scratch and you want auto-generated base dimensions
-- Model is out of sync with the database
+**When to trigger:** new/renamed/deleted tables or columns, a new view that needs auto-generated base dimensions, or any time the model is out of sync with the database.
 
 **What it does:** Introspects your data warehouse, auto-generates base dimensions with correct types and timeframes, detects deletions and broken references. Runs as a background job (can take several minutes).
 
@@ -120,6 +112,8 @@ omni models yaml-create <modelId> --body '{
 ```
 
 > **Note**: The `branchId` parameter must be a UUID from the server (Step 0). Passing a string name instead will return `400 Bad Request: Unrecognized key: "branchName"`.
+
+> **⚠️ Editing an existing file? `fileName` is its exact path, not a regex (unlike on read).** Reuse the full-path key from your `yaml-get` response verbatim, including any folder prefix — e.g. `MARTS/fct_ai_events.view`, not `fct_ai_events.view`. A non-matching `fileName` doesn't error: Omni **silently creates a new file at that path** and returns `success: true`, so shortening the key produces a duplicate view at the repo root.
 
 ### Step 2: Validate and Test
 
@@ -191,6 +185,8 @@ omni models yaml-get <modelId> --filename your_view.view --branchid <branchId>
 ```
 
 Confirm your new fields are listed in the response. If they're missing, the YAML write may have silently failed (e.g., wrong `fileName`, malformed YAML string) — or the view may live in an offloaded schema that `yaml-get` doesn't surface. Before concluding a view doesn't exist, run the lazy-load fallback (see "Fallback: View Missing from yaml-get" below).
+
+> **Confirm you didn't create a duplicate.** `success: true` means accepted, not that it hit the intended file (see Step 1). Re-list files and check the same view name doesn't now exist at two paths (e.g. `MARTS/foo.view` and `foo.view`); if it does, delete the stray one (empty `yaml`) and re-write with the full-path key.
 
 ### Step 3: Ship the Branch
 
@@ -489,23 +485,11 @@ Query views can also be defined inline within a topic's `views:` block, scoping 
 | "Invalid YAML syntax" | Check indentation (2 spaces, no tabs) |
 | Fanout / incorrect aggregations on joins | Add `primary_key: true` to the joined view — every view that participates in a join must have a primary key |
 | Column reference error (e.g., "Column `X` not found") | Check that the table exists and your Omni connection has access |
+| Duplicate view appeared at the repo root after an edit | You wrote with a bare `fileName` instead of the file's full path. Delete the stray root file (send empty `yaml` to it) and re-write using the exact `files` key, including its folder prefix (e.g. `MARTS/`) |
 
 ## Troubleshooting: Model Out of Sync with Database
 
-If your model doesn't reflect the database (missing columns, broken references, wrong types), trigger a schema refresh (see "Schema Refresh" section above). Then validate:
-
-```bash
-omni models validate <modelId>
-```
-
-Common issues and fixes:
-
-| Issue | Cause | Fix |
-|-------|-------|-----|
-| **Broken column references** | Column no longer exists in database | Remove or update the `sql` reference |
-| **Field name collision** | Auto-generated dimension conflicts with your measure | Suppress with `hidden: true` or rename |
-| **Unknown field types** | Type info not available from schema | Verify column exists and connection has access |
-| **Missing tables** | Table not in schema after refresh | Verify table exists and connection includes its database/schema |
+If the model doesn't reflect the database (missing columns/tables, wrong types, broken references), trigger a schema refresh (see "Schema Refresh" above), then `omni models validate <modelId>`. Field-name collisions and broken column references are usually fixed with `hidden: true` or a rename (see "Common Validation Errors"); persistent missing tables mean the connection lacks access to that database/schema.
 
 ## Docs Reference
 

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -104,6 +104,8 @@ omni models yaml-get <modelId> --branchid <branchId>
 
 The `mode` parameter: `combined` (default) merges schema + shared model; `extension` shows only shared model customizations.
 
+The `files` map is keyed by each file's **full stored path** (e.g. `MARTS/order_items.view`), and `--filename` is a regex on read. Reuse that exact key — including any folder prefix — when editing with `omni-model-builder`; a shortened name creates a duplicate instead of editing the original.
+
 ## Model Architecture
 
 Omni has three layers:


### PR DESCRIPTION
## Human note

We have to guide the AI to be careful when pushing to files, because if they target the name without the path, it will result in an orphaned / dupe file.

Customer recently ran into this and I just happened upon it by chance while working on some changes. This PR should address:
1. stronger guidance for file names (agent should use what it gets back from api)
2. handling dupes if they're created by accident
3. make the overall model building agent file more concise to get closer to 500 line guidance for skills

## Problem

An agent using `omni-model-builder` accidentally created a **duplicate `.view` file** while trying to edit an existing one. It read the view with a loose `yaml-get` regex (`.*ai_events.*`), which returned the file keyed by its full path `MARTS/fct_ai_daily_org_model_interface.view`, then wrote it back with the **bare** `fct_ai_daily_org_model_interface.view`.

Because `yaml-create` treats `fileName` as an **exact path identity** with **create-on-miss** behavior, the bare name matched nothing and Omni **silently created a new file at the repo root** — returning `success: true` with no error. Result: two views with the same name on the branch.

The docs invited this: the only `fileName` example is a bare name, the read response's full-path keying is undocumented, and the read-regex / write-exact asymmetry is never called out.

## Changes (docs only)

**Footgun fix**
- `omni-model-builder` Step 1: ⚠️ callout that write `fileName` is the file's exact path — reuse the full-path key from the read response verbatim (incl. folder prefix); shortening it creates a duplicate at the root.
- `omni-model-builder` Step 2d: post-write anti-duplicate read-back check (`success: true` ≠ landed on the intended file).
- `omni-model-builder` Common Validation Errors: troubleshooting row for "duplicate view appeared at repo root."
- `omni-model-explorer` Step 4: document that the `files` map is keyed by full stored path and those keys must be reused verbatim on write.

**Concision (folded in per skill-length guidance)**
The builder skill was already **518 lines** (over the ~500 guidance) before this change. Trimmed genuine redundancy so it lands at **502** even with the additions above:
- Collapsed the "Troubleshooting: Model Out of Sync" table (it duplicated the Schema Refresh section + Common Validation Errors).
- Collapsed the Schema Refresh "When to trigger" bullets to one line.
- Merged the duplicated layering prose in the Architecture section.
- Inlined the `-o json` tip.

Net: builder **518 → 502**; explorer **197 → 199**.

## Notes for reviewers
- Docs-only; no behavioral/code changes. Adapted to the CLI (`omni models ...`) style used in this repo.
- Worth a separate discussion: the underlying footgun is the **API**'s silent create-on-miss returning `success: true`. A `requireExisting`/upsert flag or a 404 on non-matching writes would eliminate this class of error API-side. Flagging for the API team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)