### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger mintlify-omni docs sync
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.DOCS_REPO_TOKEN }}
           repository: exploreomni/mintlify-omni

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -31,7 +31,7 @@ jobs:
           echo "head_ref=$PR_HEAD" >> $GITHUB_OUTPUT
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.pr.outputs.head_ref }}
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run skill review
         if: steps.changed-files.outputs.files != ''
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@bbfaf8e1ffe3e688f7ab65ceee78de241e24a238 # v1
         with:
           use_claude_code_app: true
           track_progress: true

--- a/.github/workflows/sync-cli-changes.yml
+++ b/.github/workflows/sync-cli-changes.yml
@@ -18,7 +18,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Resolve release tag
         id: release
@@ -49,7 +49,7 @@ jobs:
           # Fetch release notes
           gh release view "$TAG" --repo exploreomni/cli --json tagName,name,body > /tmp/cli-release-meta.json
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@bbfaf8e1ffe3e688f7ab65ceee78de241e24a238 # v1
         id: sync
         with:
           use_claude_code_app: true

--- a/.github/workflows/update-skills-security-audits.yml
+++ b/.github/workflows/update-skills-security-audits.yml
@@ -13,7 +13,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Refresh README audit table
         run: |


### PR DESCRIPTION
## Summary
- Org policy rejected workflow runs with the error: `actions/checkout@v4 is not allowed ... all actions must be pinned to a full-length commit SHA`
- Pins all `uses:` references in `.github/workflows/` to full SHAs, with version comments retained for readability:
  - `actions/checkout` → `34e1148…` (v4)
  - `peter-evans/repository-dispatch` → `ff45666…` (v3)
  - `anthropics/claude-code-action` → `bbfaf8e…` (v1)

## Test plan
- [ ] Confirm GitHub Actions accepts the pinned references on the next workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)