### PR TITLE
Bump actions/checkout to v6.0.2 (Node.js 24)

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -31,7 +31,7 @@ jobs:
           echo "head_ref=$PR_HEAD" >> $GITHUB_OUTPUT
 
       - name: Checkout PR branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.pr.outputs.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/sync-cli-changes.yml
+++ b/.github/workflows/sync-cli-changes.yml
@@ -18,7 +18,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Resolve release tag
         id: release

--- a/.github/workflows/update-skills-security-audits.yml
+++ b/.github/workflows/update-skills-security-audits.yml
@@ -13,7 +13,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Refresh README audit table
         run: |


### PR DESCRIPTION
## Summary
- GitHub warned that `actions/checkout@v4` runs on Node.js 20, which is being deprecated (forced Node 24 default 2026-06-02, Node 20 removed 2026-09-16).
- Bumps all three pinned references to `actions/checkout@de0fac2e…` (v6.0.2), the first major version on Node.js 24.

## Test plan
- [ ] Next workflow run no longer emits the Node 20 deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)