### PR TITLE
Harden omni-to-databricks-metric-view skill (1.1.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
       "name": "omni-integrations",
       "source": "./skills/omni-integrations",
       "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, and more.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "Omni Analytics"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.1.1] - 2026-05-23
+
+### omni-integrations
+
+**Changed**
+- `omni-to-databricks-metric-view` — replaced `cat ~/.databrickscfg` with `databricks auth profiles` so the skill no longer instructs the agent to read a credentials file. Replaced the shell-substituted `python3 -c '...'` JSON-encoding step in the SQL Statements API call with a `--json @payload.json` pattern, dropping the extra interpreter and shell substitution of generated SQL. Brings the Gen Agent Trust Hub audit profile closer to the Snowflake peer skill (see https://www.skills.sh/exploreomni/omni-agent-skills/omni-to-databricks-metric-view/security/agent-trust-hub).
+
 ## [1.3.11] - 2026-05-22
 
 ### omni-analytics

--- a/skills/omni-integrations/.claude-plugin/plugin.json
+++ b/skills/omni-integrations/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-integrations",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
   "author": {
     "name": "Omni Analytics",

--- a/skills/omni-integrations/.cursor-plugin/plugin.json
+++ b/skills/omni-integrations/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-integrations",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
   "author": {
     "name": "Omni Analytics",

--- a/skills/omni-integrations/skills/omni-to-databricks-metric-views/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-databricks-metric-views/SKILL.md
@@ -27,9 +27,9 @@ omni config use <profile-name>
 ```
 
 ```bash
-# Databricks CLI — verify installed and check profiles
+# Databricks CLI — verify installed and list configured profile names
 databricks --version
-cat ~/.databrickscfg
+databricks auth profiles
 ```
 
 ---
@@ -253,17 +253,23 @@ version: 1.1
 $$
 ```
 
-Execute via the SQL Statements API (`databricks sql execute` does not exist in CLI v0.295.0+):
+Execute via the SQL Statements API (`databricks sql execute` does not exist in CLI v0.295.0+).
+
+Write the request body as a JSON file (with the SQL embedded as a properly-quoted string) and pass it via `--json @file`. This avoids shell substitution of arbitrary SQL content into the command line:
 
 ```bash
-databricks api post /api/2.0/sql/statements \
-  --json "{
-    \"warehouse_id\": \"<WAREHOUSE_ID>\",
-    \"statement\": $(cat /tmp/orders_mv.sql | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
-    \"wait_timeout\": \"50s\",
-    \"catalog\": \"<CATALOG>\",
-    \"schema\": \"<SCHEMA>\"
-  }"
+# /tmp/orders_mv.payload.json
+{
+  "warehouse_id": "<WAREHOUSE_ID>",
+  "statement": "<SQL with newlines as \\n and quotes as \\\">",
+  "wait_timeout": "50s",
+  "catalog": "<CATALOG>",
+  "schema": "<SCHEMA>"
+}
+```
+
+```bash
+databricks api post /api/2.0/sql/statements --json @/tmp/orders_mv.payload.json
 ```
 
 Check the response for `"state": "SUCCEEDED"`. If `"state": "FAILED"`, read `status.error.message` and see the Troubleshooting section below.


### PR DESCRIPTION
## Summary

Address two HIGH findings from the [Gen Agent Trust Hub audit for `omni-to-databricks-metric-view`](https://www.skills.sh/exploreomni/omni-agent-skills/omni-to-databricks-metric-view/security/agent-trust-hub) (Apr 24, 2026 — overall FAIL):

- **CREDENTIALS_UNSAFE** — Skill instructed the agent to `cat ~/.databrickscfg`. Replaced with `databricks auth profiles`, which lists profile names without exposing tokens.
- **COMMAND_EXECUTION** (partial mitigation) — Replaced the shell-substituted `python3 -c 'import json,sys; print(json.dumps(...))'` JSON-encoding step in the SQL Statements API call with a `--json @payload.json` pattern. Drops the extra interpreter and removes shell substitution of generated SQL into the command line.

The Snowflake peer skill ([`omni-to-snowflake-semantic-view`](https://www.skills.sh/exploreomni/omni-agent-skills/omni-to-snowflake-semantic-view/security/agent-trust-hub)) audits **Pass** with the same overall shape (Omni → external warehouse, CLI calls, DDL). These changes bring the Databricks skill in line. `PROMPT_INJECTION` is also flagged but is intrinsic to carrying Omni YAML field values into the output; the Snowflake peer is rated "Medium · Documented Risk" for the same pattern — likely auditor variance, no structural fix attempted.

### Version bump
- `omni-integrations` plugin: 1.1.0 → 1.1.1 (patch — security hardening, no behavior change)

## Test plan
- [ ] Re-run / wait for the Gen Agent Trust Hub audit to re-score `omni-to-databricks-metric-view` and confirm CREDENTIALS_UNSAFE clears and COMMAND_EXECUTION drops in severity.
- [ ] Manually verify a `CREATE OR REPLACE VIEW ... WITH METRICS` round-trip still works via the `--json @payload.json` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)