### PR TITLE
Fix invalid ${TABLE}.column examples in omni-model-builder

### DIFF
--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -339,12 +339,27 @@ Result: `created_at` inherits its type from the schema layer (DATE with automati
 
 **Key insight**: If your extension defines a dimension but there's no schema layer base dimension to provide type information, Omni can't infer granularities or types. Trigger a schema refresh to auto-generate the schema layer first.
 
+**Reading back what you wrote — `--mode`.** `yaml-get` returns your **extension** layer by default — just the deltas you authored, *not* the auto-generated base columns. To see the **fully-composed** result (schema base + your extension merged), read with `--mode combined`:
+
+```bash
+# What you authored (deltas only) — default
+omni models yaml-get <modelId> --filename your_view.view --branchid <branchId> --mode extension
+
+# What the model actually resolves to (schema + extension merged)
+omni models yaml-get <modelId> --filename your_view.view --branchid <branchId> --mode combined
+```
+
+Use `extension` to confirm *what you changed*, and `combined` to confirm *what the model resolves to*. When the model is git-integrated, the **combined** output mirrors what's written to the repository — which is why committed `*.view.yaml` files carry the schema-layer `table_name:` and base columns, while the extension layer holds only your deltas. (Other `--mode` values: `staged`, `merged`, `history`.)
+
 ### Dimension Parameters
 
 See `references/modelParameters.md` for the complete list of 35+ dimension parameters, format values, and timeframes.
 
 Most common parameters:
-- `sql` — SQL expression using `${field_name}` references
+- `sql` — SQL expression using `${field_name}` references. Reference other fields
+  with `${field}` / `${view.field}`; a raw column auto-maps by name (no `sql:`).
+  There is no `${TABLE}` construct — `${TABLE}.column` errors with
+  `Column "__omni_scoped" not found` at validation and query time.
 - `label` — display name · `description` — help text (also used by Blobby)
 - `primary_key: true` — unique key (critical for aggregations)
 - `hidden: true` — hides from picker, still usable in SQL

--- a/skills/omni-model-builder/references/modelParameters.md
+++ b/skills/omni-model-builder/references/modelParameters.md
@@ -42,6 +42,14 @@ Complete parameter reference for views, topics, dimensions, and measures. Use th
 | `ignore_from_extended` | Controls field omission during view extensions |
 | `custom_primary_key_sql_for_quick_aggs` | Custom primary key for aggregate measures |
 
+> **`sql` references fields, not `${TABLE}`.** Use `${field}` / `${view.field}`
+> to reference another defined dimension or measure. There is **no `${TABLE}`
+> construct in Omni** — `${TABLE}.column` is a LookML-ism that does not resolve;
+> it errors with `Column "__omni_scoped" not found` at both `omni models
+> validate` (blocking) and query time. To use a raw database column, just let
+> the dimension auto-map by its column name (no `sql:` needed); only add `sql:`
+> for derived/computed expressions, referencing other fields via `${field}`.
+
 ### Common dimension examples
 
 ```yaml
@@ -60,12 +68,12 @@ dimensions:
     timeframes: [raw, date, week, month, quarter, year]
 
   sale_price:
-    sql: ${TABLE}.sale_price
+    # A plain column dimension auto-maps by name — no `sql:` needed.
     format: currency_2
     hidden: true
 
   customer_tier:
-    sql: ${TABLE}.tier
+    sql: ${tier}
     groups:
       - filter:
           is: [enterprise, strategic]
@@ -297,7 +305,7 @@ Bucket string field values using CASE-like logic:
 ```yaml
 dimensions:
   customer_segment:
-    sql: ${TABLE}.tier
+    sql: ${tier}
     groups:
       - filter:
           is: [enterprise, strategic]


### PR DESCRIPTION
## What

`${TABLE}.column` is a LookML-ism that **does not resolve in Omni**. It compiles to a phantom column and errors with `Column "__omni_scoped" not found` — caught as a **blocking error** by `omni models validate` *and* again at query plan time.

The `omni-model-builder` skill currently teaches it in three example snippets in `references/modelParameters.md`, so a model author following the reference produces YAML that won't validate or query.

## Changes

`skills/omni-model-builder/references/modelParameters.md`
- `sale_price` example — drop the `sql: ${TABLE}.sale_price` line; a plain column dimension **auto-maps by name** (no `sql:` needed).
- `customer_tier` and `customer_segment` examples — `sql: ${TABLE}.tier` → `sql: ${tier}` (reference the field).
- Add a caution note: there is no `${TABLE}` construct; reference fields with `${field}` / `${view.field}`, or let raw columns auto-map by name.

`skills/omni-model-builder/SKILL.md`
- Add the same one-line caution to the `sql` entry under **Dimension Parameters**.
- Add a **"Reading back what you wrote — `--mode`"** note to the *Schema Layer vs Extension Layer* section: `yaml-get` returns the **extension** layer (your deltas) by default; read `--mode combined` to see the fully-composed (schema + extension) result. Notes that **combined mirrors the git repository** when the model is git-integrated, which is why committed `*.view.yaml` files carry the schema-layer `table_name:`/base columns.

No behavioral/runtime code — docs only. After this change, `grep '${TABLE}'` returns only the new caution prose that names the anti-pattern.

## How verified

Reproduced on a live Snowflake-backed instance: a dimension with `sql: ${TABLE}.<col>` is flagged by `omni models validate` as a blocking error (`Column "__omni_scoped" not found`, `is_warning: false`) and fails identically at query plan time, in both a real-view extension and a standalone view. The same field written with `${field}` (or auto-mapped) validates clean and returns data.

---
_Filed by Claude on behalf of @barberscott._