### PR TITLE
docs(omni-model-builder): refresh query-view mapping example

### DIFF
--- a/skills/omni-model-builder/references/query-view-examples.md
+++ b/skills/omni-model-builder/references/query-view-examples.md
@@ -66,21 +66,31 @@ dimensions:
 
 ## Mapping / lookup view (CLI stand-in for an Omni Input Table)
 
-To rebuild a **hardcoded key→label lookup** — e.g. a dashboard-defined dimension that remaps `region_name` → a rep name (the kind of grouping/alias built in a BI tool's UI rather than the database), or any mapping that lives only in a dashboard (not in the database) — model it as **data joined on the key**, not a `CASE`. The maintainable ideal is an **Omni Input Table** (a writable table created/edited in the Omni UI — there is **no CLI command** for input tables under `connections`/`models`/`documents`). The **CLI-buildable equivalent** is a hardcoded `VALUES`/`UNION ALL` **query view** joined on the key:
+To rebuild a **hardcoded key→label lookup** — e.g. a dashboard-defined dimension that remaps `territory` → a rep name (the kind of grouping/alias built in a BI tool's UI rather than the database), or any mapping that lives only in a dashboard (not in the database) — model it as **data joined on the key**, not a `CASE`. The maintainable ideal is an **Omni Input Table** (a writable table created/edited in the Omni UI — there is **no CLI command** for input tables under `connections`/`models`/`documents`). The **CLI-buildable equivalent** is a hardcoded `VALUES`/`UNION ALL` **query view** joined on the key:
 
 ```yaml
-# region_rep_map.query.view  — Reference this view as region_rep_map
+# territory_rep_map.query.view  — Reference this view as territory_rep_map
 sql: |
-  SELECT 'East' AS "region_name", 'Mike Parker'        AS "employee_name"
-  UNION ALL SELECT 'West',          'Alexandra Peterson'
-  UNION ALL SELECT 'Great Lakes',   'Jennifer Trevino'
-  -- ...one row per source value; repeat the label across rows for many-to-one (several keys → one label)
+  SELECT 'Tri-State Area'      AS "territory", 'Daniel Carter'     AS "employee_name", 'Thomas Mitchell'  AS "manager_name"
+  UNION ALL SELECT 'The Beltway',        'Nancy Reed',        'Thomas Mitchell'
+  UNION ALL SELECT 'New England',        'Steven Bennett',    'Thomas Mitchell'
+  UNION ALL SELECT 'Tampa Bay',          'Laura Foster',      'Thomas Mitchell'
+  UNION ALL SELECT 'Chicagoland',        'Brian Hughes',      'Sandra Powell'
+  UNION ALL SELECT 'The Metroplex',      'Rachel Long',       'Sandra Powell'
+  UNION ALL SELECT 'Twin Cities',        'Kevin Price',       'Sandra Powell'
+  UNION ALL SELECT 'Gulf Coast',         'Amanda Ross',       'Sandra Powell'
+  UNION ALL SELECT 'SoCal',              'Gregory Barnes',    'Joseph Bryant'
+  UNION ALL SELECT 'The Bay Area',       'Michelle Coleman',  'Joseph Bryant'
+  UNION ALL SELECT 'Pacific Northwest',  'Andrew Russell',    'Joseph Bryant'
+  UNION ALL SELECT 'Mountain West',      'Andrew Russell',    'Joseph Bryant'   -- repeat labels for many-to-one (several territories → one rep/manager)
+  -- ...one row per source value (mix of metro nicknames and broader regions)
 
 dimensions:
-  region_name: {}
+  territory: {}
   employee_name: {}
+  manager_name: {}
 
-custom_compound_primary_key_sql: [ '"region_name"' ]   # single-col PK is fine
+custom_compound_primary_key_sql: [ '"territory"' ]   # single-col PK is fine
 ```
 
 Then join it on the key (topic-scoped relationship):
@@ -88,14 +98,14 @@ Then join it on the key (topic-scoped relationship):
 ```yaml
 relationships:
   - join_from_view: <territory/base view>
-    join_to_view: region_rep_map
+    join_to_view: territory_rep_map
     join_type: always_left
     relationship_type: many_to_one
-    on_sql: ${<territory/base view>.region_name} = ${region_rep_map.region_name}
+    on_sql: ${<territory/base view>.territory} = ${territory_rep_map.territory}
 ```
 
-`employee_name` is now a real **dimension** — group, filter, and query by it like any field. Notes:
-- **Quote the SELECT aliases** (`AS "region_name"`) on Snowflake/BigQuery/Databricks or they uppercase and the join key won't match.
+`employee_name` and `manager_name` are now real **dimensions** — group, filter, and query by them like any field. Notes:
+- **Quote the SELECT aliases** (`AS "territory"`) on Snowflake/BigQuery/Databricks or they uppercase and the join key won't match.
 - `always_left` → unmatched keys render as `∅`/null. Add an `'Other'` catch-all (a final `UNION ALL SELECT <unmatched>, 'Other'` is impractical for open domains — instead `COALESCE(${map.label}, 'Other')` in a derived dim, or accept nulls) to give unmatched keys a catch-all `'Other'` bucket.
 - Validates clean; the grouped query runs COMPLETE and mapped labels flow into results.
 - Prefer a true **UI Input Table** when the mapping changes over time (reps reassigned) — it's editable in-app; the query view requires a YAML edit to change.


### PR DESCRIPTION
## What
Refreshes the territory→rep mapping query-view example in `skills/omni-model-builder/references/query-view-examples.md`:
- renames the key column `region_name` → `territory`
- uses a mix of metro-area nicknames and broader regional terms for the territory values
- adds a `manager_name` column with a second set of sample names

## Why
Keeps the example gallery example with sample name but adds territory→manager grouping which doubles as a second many-to-one example (several territories map to one manager), alongside the existing rep-level case.

This example is linked from `omni-model-builder/SKILL.md` and read on demand when building query views.

## Validation
Built on a throwaway branch of a Snowflake-backed model and queried: validates clean, the `UNION ALL` SQL compiles, and all rows return with the quoted aliases resolving to real dimensions.

## Notes
- Single-file, docs-only change; no changelog entry.