### PR TITLE
feat(omni-model-builder): content validator find-and-replace for rename propagation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.4.1"
+    "version": "1.5.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.4.2",
+  "version": "1.5.0",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.4.2"
+    "version": "1.5.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "omni-analytics",
 
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {
     "name": "Omni Analytics",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.5.0] - 2026-06-22
+
+### omni-analytics
+
+_Summary: teach the modeler the **write half** of the content validator — propagating a rename across saved content — to complement the detect half already in `omni-model-explorer`._
+
+**Added**
+- `omni-model-builder` documents **propagating renames across content** with the content validator: a new *Propagating Renames Across Content* section in `SKILL.md` and a `references/content-validator.md` covering both operations — `omni models content-validator-get` (detect blast radius; flags `--content-filter-mode`, `--find`/`--find-type`, `--folder-paths`, `--labels`, `--include-personal-folders`, `--branch-id`) and `omni models content-validator-replace` (find-and-replace via JSON `--body`: required `find`/`replacement`/`find_or_replace_type`, optional `branch_id`/`creator_id`/`folder_paths`/`labels`/`only_in_workbook_id`), with the detect-first + branch-scoping safety model and a worked field-rename example. Adds a model-builder eval case for the rename-propagation flow.
+- `omni-modeler` agent gains a **Propagate Renames** workflow step (between Test and Ship) that routes rename/removal impact through `omni-model-builder`'s content validator workflow on the branch before shipping.
+
+**Changed**
+- `omni-model-builder` **Known Issues & Safe Defaults** now warns that renames don't auto-propagate to saved content and that a non-branch `content-validator-replace` has no undo. `omni-yaml-conventions` rule adds the matching pitfall. (Also syncs the `.claude-plugin/marketplace.json` omni-analytics version, which had drifted to 1.4.1.)
+
 ## [1.4.2] - 2026-06-19
 
 ### omni-analytics

--- a/agents/omni-modeler.md
+++ b/agents/omni-modeler.md
@@ -36,7 +36,9 @@ You are a senior analytics engineer building Omni's semantic model. Your job is 
 
 5. **Test**: Use `omni-query` to run a query that exercises the new fields. Verify the results make sense.
 
-6. **Ship**: Once validated and tested, check `omni models git-get <modelId>`. If git-connected, use `omni models commit` to open or update a PR and return the `pr_url` to the user. If not, use `omni models merge-branch` after user confirmation. See `omni-model-builder` Step 3 for the full command shape.
+6. **Propagate Renames**: If the change renames or removes a view, field, or topic that saved content references, dependent dashboards and workbooks still point at the old name. Use `omni-model-builder`'s content validator workflow to detect the blast radius and find-and-replace the references **on the branch** before shipping. Report what was rewritten and confirm with the user.
+
+7. **Ship**: Once validated and tested, check `omni models git-get <modelId>`. If git-connected, use `omni models commit` to open or update a PR and return the `pr_url` to the user. If not, use `omni models merge-branch` after user confirmation. See `omni-model-builder` Step 3 for the full command shape.
 
 ## Model Quality Standards
 

--- a/rules/omni-yaml-conventions.mdc
+++ b/rules/omni-yaml-conventions.mdc
@@ -119,3 +119,4 @@ omni models yaml-create <modelId> --body '{
 - Wrong `relationship_type` causes fanout errors
 - Forgetting `join_paths_from_topic_name` in queries leads to "no join path" errors
 - YAML indentation errors — use 2 spaces, no tabs
+- Renaming a field/view/topic does **not** update saved dashboards or workbooks — propagate the references with the content validator (see `omni-model-builder`)

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -59,9 +59,16 @@ The **schema layer** is auto-generated from your database. When your database sc
 
 See `references/schema-refresh.md` for when to trigger, what it does and its side effects, the deleted/renamed-column impact-check workflow, and connection/credential error handling.
 
+## Propagating Renames Across Content (Content Validator)
+
+Renaming or removing a view, field, or topic does **not** update the dashboards and workbooks that reference it — saved queries keep the old name and break. Use the content validator to detect the blast radius (`omni models content-validator-get`) and then bulk-rewrite references to the new name (`omni models content-validator-replace`). Always detect first, scope the replace to a **branch** so it's reversible, and confirm before any direct-to-published (non-branch) replace, which has no undo.
+
+See `references/content-validator.md` for the detect-then-propagate workflow, the verified `get` flags and `replace` `--body` schema, filter scoping (`folder_paths` / `labels` / `creator_id` / `only_in_workbook_id`), and the safety model.
+
 ## Known Issues & Safe Defaults
 
 - **Do not merge without explicit confirmation** — after branch validation and query testing, stop and ask the user before `omni models merge-branch`, even when the model is not git-connected. Treat requests like "add a field" or "create a view" as requests to prepare validated branch changes, not as permission to ship to production.
+- **Renames don't auto-propagate to saved content, and a non-branch replace has no undo** — after renaming a field/view/topic, dependent dashboards and workbooks still reference the old name. Propagate with the content validator (above), scoped to a branch. A `content-validator-replace` without a `branch_id` rewrites published content directly and cannot be rolled back in-product — confirm before running one.
 - **Keep eval-created files on branches until confirmed** — if you create fields/views for validation, report the branch name/id, validation status, and test query result. Only merge after the user explicitly says to merge, ship, publish, or promote.
 
 ## Discovering Commands
@@ -467,6 +474,6 @@ If the model doesn't reflect the database (missing columns/tables, wrong types, 
 
 ## Related Skills
 
-- **omni-model-explorer** — understand the model before modifying
+- **omni-model-explorer** — understand the model before modifying; also runs `content-validator-get` for impact analysis
 - **omni-ai-optimizer** — add AI context after building topics
 - **omni-query** — test new fields

--- a/skills/omni-model-builder/evals/evals.json
+++ b/skills/omni-model-builder/evals/evals.json
@@ -55,6 +55,18 @@
         "The agent reports validation warnings separately and does not claim they were caused by the deleted column unless validation or content-validator output identifies the missing table or column"
       ],
       "expected_skill": "omni-model-builder"
+    },
+    {
+      "id": "5",
+      "question": "I renamed the field order_items.sale_price to order_items.unit_price in the model. Update every dashboard and workbook that still references the old name.",
+      "ground_truth": "Work happens on a branch. The agent runs content-validator-get to find content referencing the old field (blast radius) before changing anything, then runs content-validator-replace with find_or_replace_type FIELD, find order_items.sale_price, replacement order_items.unit_price, scoped with branch_id so the rewrites become drafts. It reports the replaced-document counts and asks for confirmation before merging; it does not run a non-branch (direct-to-published) replace without explicit confirmation, since that has no undo.",
+      "expected_behavior": [
+        "The agent runs omni models content-validator-get to identify which documents reference the old field before replacing, and reports the blast radius",
+        "The agent runs omni models content-validator-replace with find_or_replace_type FIELD and view.field dotted notation in both find (order_items.sale_price) and replacement (order_items.unit_price)",
+        "The replace is scoped to a branch via branch_id rather than rewriting published content directly; if the agent proposes a non-branch replace it first warns there is no undo and asks for confirmation",
+        "The agent reports which documents were rewritten (replace counts) and asks for confirmation before merging the branch to production"
+      ],
+      "expected_skill": "omni-model-builder"
     }
   ]
 }

--- a/skills/omni-model-builder/references/content-validator.md
+++ b/skills/omni-model-builder/references/content-validator.md
@@ -1,0 +1,79 @@
+# Content Validator: Propagating Renames Across Saved Content
+
+Renaming or removing a view, field, or topic in the model **does not** update the dashboards and workbooks that reference it — those saved queries keep pointing at the old name and silently break. The content validator is the tool that (a) finds every piece of saved content referencing a model object, and (b) bulk-rewrites those references to the new name.
+
+Two operations, both under `omni models`:
+
+| Command | Direction | Purpose |
+|---------|-----------|---------|
+| `content-validator-get` | read | Detect broken references / blast radius. Returns the documents that reference a target view/field/topic, plus any validation issues. |
+| `content-validator-replace` | write | Find-and-replace a reference across all in-scope content. |
+
+> **Detect first.** `content-validator-get` is also surfaced by `omni-model-explorer` for impact analysis. Always run it to preview the blast radius **before** replacing.
+
+## Safety — read before replacing
+
+- **Prefer a branch.** With `branch_id`, replacements are written as branch-attached **drafts** and only published when the branch merges — fully reversible by not merging. Without a branch, the replace mutates **published** content directly.
+- **There is no undo.** A main-branch (no `branch_id`) replace cannot be rolled back in-product. Recovery means running the reverse replace by hand. Confirm with the user before any non-branch replace.
+- **Always `content-validator-get` first**, report the blast radius, and get confirmation before the write.
+- Documents requiring a pull request to publish are skipped on a non-branch replace (reported in `skipped_pr_required_count`).
+
+## Detect: `content-validator-get`
+
+```bash
+omni models content-validator-get <modelId> --branch-id <branchId>
+```
+
+Verify flags with `omni models content-validator-get --help`. Scope filters:
+
+| Flag | Meaning |
+|------|---------|
+| `--branch-id` | Validate against a branch (draft + published merged). |
+| `--content-filter-mode` | `ALL` (default) \| `WITH_ISSUES` (only docs with a query/filter issue or document error) \| `NO_ISSUES`. |
+| `--find` + `--find-type` | Scope to content referencing one object. `--find-type` is `VIEW`, `FIELD`, or `TOPIC`; both flags must be supplied together. `FIELD` values must be `view_name.field_name`. |
+| `--folder-paths` | Prefix-match folders, e.g. `/Finance` matches `/Finance/Reports`. |
+| `--labels` | Comma-separated label names (unknown label → 400). |
+| `--include-personal-folders` | Include users' personal folders. |
+| `--userid` | Act on behalf of a membership (org-scoped API keys only). |
+
+An empty `content` array means no saved content references the target — i.e. no breakage.
+
+## Propagate: `content-validator-replace`
+
+The replace operation takes a **JSON `--body`** (not per-field flags). Verify with `omni models content-validator-replace --help`.
+
+```bash
+omni models content-validator-replace <modelId> --body '{
+  "find": "order_items.sale_price",
+  "replacement": "order_items.unit_price",
+  "find_or_replace_type": "FIELD",
+  "branch_id": "<branchId>"
+}'
+```
+
+Body fields:
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `find` | string | ✅ | What to find. For `FIELD`, must be `view.field` dotted notation. |
+| `replacement` | string | ✅ | The new value. For `FIELD`, also `view.field`. |
+| `find_or_replace_type` | `FIELD` \| `VIEW` \| `TOPIC` | ✅ | `VIEW` renames a view ref; `FIELD` a `view.field` ref; `TOPIC` a topic ref. |
+| `branch_id` | string | – | **Strongly recommended** — writes drafts, published at merge. Omit only for an irreversible direct-to-published replace. |
+| `creator_id` | string (UUID) | – | Limit to documents created by this membership (unknown → 400). |
+| `folder_paths` | string **array** | – | Limit to these folder prefixes. Note: native JSON array here (the GET REST endpoint takes a URL-encoded string instead). |
+| `include_personal_folders` | boolean | – | Default `false`. |
+| `labels` | string (comma-separated) | – | Limit to documents carrying any of these labels. |
+| `only_in_workbook_id` | string | – | Replace within a single workbook only. |
+
+The response reports counts: `replaced_queries_count`, `replaced_documents_count`, `replaced_workbook_models_count`, `replaced_dashboard_filters_count`, `skipped_pr_required_count`.
+
+**Validation:** `FIELD` requires a `.` in **both** `find` and `replacement`. Unknown `creator_id` / `labels` return 400.
+
+## Workflow: rename a model field and propagate it
+
+1. **Branch + rename in the model.** Create a branch and make the rename in YAML (see the main skill's Safe Development Workflow), then `omni models validate`.
+2. **Detect.** `content-validator-get <modelId> --branch-id <branchId> --find order_items.sale_price --find-type FIELD` — report which documents reference the old field.
+3. **Propagate on the branch.** `content-validator-replace <modelId> --body '{"find":"order_items.sale_price","replacement":"order_items.unit_price","find_or_replace_type":"FIELD","branch_id":"<branchId>"}'`.
+4. **Confirm.** Report the replace counts and ask before shipping. Ship the branch the usual way (`omni models commit` for git-connected, else `omni models merge-branch` after confirmation) — the drafts publish on merge.
+
+Scope a large rename with `folder_paths` / `labels` / `creator_id` / `only_in_workbook_id` when the user only wants part of the content rewritten.


### PR DESCRIPTION
## Summary

Teaches `omni-model-builder` the **write half** of the content validator — propagating a rename across saved dashboards/workbooks — to complement the **detect** half already in `omni-model-explorer`. Closes the gap where renaming a view/field/topic silently breaks dependent content.

## Changes

- **`references/content-validator.md`** (new) — detect-then-propagate workflow: `omni models content-validator-get` flags (`--content-filter-mode`, `--find`/`--find-type`, `--folder-paths`, `--labels`, `--include-personal-folders`, `--branch-id`) and `omni models content-validator-replace` JSON `--body` schema (required `find`/`replacement`/`find_or_replace_type`; optional `branch_id`/`creator_id`/`folder_paths`/`labels`/`only_in_workbook_id`), branch-safety + no-undo model, worked field-rename example.
- **`SKILL.md`** — *Propagating Renames Across Content* section, Known Issues bullet (no auto-propagate, no undo on non-branch replace), Related Skills note.
- **`agents/omni-modeler.md`** — *Propagate Renames* workflow step (Test → Propagate → Ship), routes to the skill (no CLI duplication).
- **`rules/omni-yaml-conventions.mdc`** — matching pitfall one-liner.
- **`evals/evals.json`** — rename-propagation case (#5).
- **Version** — `omni-analytics` 1.4.2 → **1.5.0** across all 4 manifests + CHANGELOG (also syncs `.claude-plugin/marketplace.json`, which had drifted to 1.4.1).

## Validation (live, against the analytics shared model)

CLI flags checked with `--help`; behavior verified end-to-end:

- `--content-filter-mode`: ALL=532, WITH_ISSUES=43, NO_ISSUES=489 (43+489=532 ✓)
- `--find`/`--find-type` pairing → `400 find and find_type must be provided together`
- FIELD non-dotted → `400 Find field must be scoped by view name`
- `--labels` unknown → `400 Unknown label(s)`
- **`content-validator-replace`** on a throwaway branch (zero-match find) returned the documented all-zero response shape; **no content modified**, branch deleted.

## Notes for reviewer

- Draft: the BenchFlow eval case is authored but the eval **harness was not run** (needs the shared eval-instance setup in `evals/SETUP.md`).
- `git diff --check` clean; all touched JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfvV7KtQJW1b9zjBzJsg3n