### PR TITLE
docs(skills): OAuth login, --schema discovery, and whoami preflight (CLI #64–66)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.4.3"
+    "version": "1.5.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "author": {
         "name": "Omni Analytics"
       },
@@ -44,7 +44,7 @@
       "name": "omni-integrations",
       "source": "./skills/omni-integrations",
       "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, and more.",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.4.3",
+  "version": "1.5.0",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 3 context rules.",
-    "version": "1.4.2"
+    "version": "1.5.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 3 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "author": {
         "name": "Omni Analytics"
       },
@@ -44,7 +44,7 @@
       "name": "omni-integrations",
       "source": "./skills/omni-integrations",
       "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "omni-analytics",
 
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {
     "name": "Omni Analytics",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.5.0] - 2026-06-25
+
+### omni-analytics
+
+_Summary: align the CLI guidance with three upstream CLI changes — OAuth browser login, a `--schema` flag for discovering request-body shapes, and a `whoami` identity/permission check — and, centrally, document how to authenticate from an agent session._
+
+**Added**
+- **`omni-api-conventions` rule** gains an **"Authenticating from an agent session"** section: `omni config login` / `omni config init --auth oauth` run an OAuth 2.1 + PKCE browser flow that opens a localhost callback and **blocks ~2 minutes**, which a headless agent can't complete. The default is to **hand off** to the user (`! omni config login <profile>`); the agent may run it directly only on a local interactive machine, never in headless/CI. Tokens auto-refresh. Plus a **"Discovering request body shapes"** section for the `--schema` flag (prints a body command's resolved JSON schema + a filled example, no token, no API call; plus the `--depth` and `--field` companions for navigating large schemas like `documents v2-create`) and a **`whoami`** preflight that triages CLI capability, auth, and permissions in one call (`unknown command` → CLI predates 1.0.7, update it; `401`/`403 Invalid bearer token` → OAuth hand-off; identity JSON → proceed) — capability-based detection rather than a brittle `--version` semver gate, plus a minimum-version note (omni ≥ 1.0.7) in the Installation section.
+- **All 9 skill prerequisites** now run `omni whoami whoami` to confirm the active profile is authenticated, and carry a compact auth note (API key vs OAuth; hand off on 401; pointer to the rule for `--schema` and `omni config init --auth oauth`).
+- **`--schema` discovery examples** in the body-authoring skills (`omni-query`, `omni-content-builder`, `omni-model-builder`, `omni-admin`, `omni-ai-eval`) — pull a command's body schema instead of guessing the JSON for `--body`.
+- **Agents** `omni-analyst` and `omni-admin-agent` now begin with a `whoami` auth/permission preflight and the OAuth hand-off path.
+
+**Changed**
+- `omni config init` setup guidance reflects upstream: profiles are created with `--name`/`--endpoint`/`--auth`, and the **API key is read from a hidden prompt — never an `--api-key` flag** (which would leak the secret into shell history and process listings).
+
+### omni-integrations
+
+**Added**
+- The Databricks and Snowflake integration skills' prerequisites gained the same `omni whoami whoami` auth check and OAuth hand-off note.
+
 ## [1.4.3] - 2026-06-25
 
 ### omni-analytics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ _Summary: align the CLI guidance with three upstream CLI changes — OAuth brows
 
 **Changed**
 - `omni config init` setup guidance reflects upstream: profiles are created with `--name`/`--endpoint`/`--auth`, and the **API key is read from a hidden prompt — never an `--api-key` flag** (which would leak the secret into shell history and process listings).
+- `omni-api-conventions` Installation note no longer tells readers to gate on `omni --version` (which would falsely reject custom/dev/`install.sh`-from-`main` builds that carry the features without a release version) — it now points at the same capability probe as the `whoami` preflight, resolving an internal contradiction in the doc.
+- `--schema` is now stated as the **source of truth** for request-body field detail; the hardcoded `--body` shapes in `omni-admin` and `documents-v2.md` are framed as worked examples / gotcha carriers that defer to `--schema` for the exhaustive field list. Also corrected the documented `--schema` output shape (the top-level `required` array is present only when the body has required fields).
 
 ### omni-integrations
 

--- a/agents/omni-admin-agent.md
+++ b/agents/omni-admin-agent.md
@@ -9,7 +9,7 @@ You are an Omni Analytics instance administrator. Your job is to manage users, g
 
 ## Workflow
 
-1. **Verify Access**: Most admin endpoints require an Organization API Key, not a Personal Access Token. If a request returns 403, advise the user to check their key type.
+1. **Verify Access**: Run `omni whoami whoami` first to confirm you're authenticated (a 401 means the active profile isn't logged in — ask the user to run `! omni config login <profile>`, an OAuth browser flow you can't complete yourself) and to read your org role and per-model permissions before attempting an action. Most admin endpoints require an Organization API Key, not a Personal Access Token. If a request returns 403, advise the user to check their key type.
 
 2. **Understand the Request**: Map the user's intent to the right API:
    - "Add a user" → SCIM Users API

--- a/agents/omni-analyst.md
+++ b/agents/omni-analyst.md
@@ -33,7 +33,7 @@ You are a principal data analyst working with Omni Analytics. Your job is to exp
 ## Conventions
 
 - Run `omni agent-help` for a quick reference of all CLI commands and common workflows
-- Configure the Omni CLI via `omni config init` or set `OMNI_BASE_URL` and `OMNI_API_TOKEN` environment variables
+- Confirm auth before querying: `omni whoami whoami` (a 401 means the active profile isn't logged in — ask the user to run `! omni config login <profile>`, an OAuth browser flow you can't complete yourself). Set up a profile with `omni config init --auth oauth`, or fall back to `OMNI_BASE_URL` / `OMNI_API_TOKEN` environment variables
 - Use `resultType: "csv"` for easier result parsing in the terminal
 - When asked about trends, default to weekly granularity and sort ascending
 - When asked about "top N", sort descending by the relevant measure and limit appropriately

--- a/rules/omni-api-conventions.mdc
+++ b/rules/omni-api-conventions.mdc
@@ -17,18 +17,22 @@ curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | s
 
 Pre-built binaries for macOS (amd64/arm64), Linux (amd64/arm64), and Windows (amd64) are available on the [GitHub Releases page](https://github.com/exploreomni/cli/releases).
 
+> OAuth login (`omni config login`), the `whoami` command, and the `--schema` body-discovery flag require **omni CLI ≥ 1.0.7**. Check with `omni --version`; if a command errors with "unknown command", the binary is too old — ask the user to update it.
+
 ## Authentication
 
-The Omni CLI resolves credentials in this order (highest wins):
+A profile authenticates with either an **API key** or **OAuth** (browser login). The CLI resolves the token in this order (highest wins):
 
 1. `--token` flag on the command
 2. `OMNI_API_TOKEN` environment variable
-3. Profile's `apiKey` from config file (set via `omni config init`)
+3. The active profile's stored credential — an `apiKey`, or an **OAuth** access token (auto-refreshed; re-login is only needed once the refresh token is gone)
 
 Two API key types exist:
 
 - **Organization API Key** — created in Settings > API Keys by an org admin. Required for SCIM user management, connection management, and most admin endpoints.
 - **Personal Access Token** — created in User Profile > Manage Account > Generate Token. Scoped to the user's permissions. Sufficient for querying, model exploration, and content browsing.
+
+OAuth logs in as the user, so an OAuth profile carries that user's own permissions (like a Personal Access Token).
 
 ### Setup
 
@@ -39,12 +43,55 @@ omni config show
 omni config use <profile-name>
 ```
 
-If no profiles exist, run `omni config init` to create one interactively.
+If no profile exists, create one with `omni config init`:
+
+```bash
+# Non-interactive OAuth (opens a browser to log in):
+omni config init --name <profile> --endpoint https://<org>.omniapp.co --auth oauth
+
+# API key (the key is read from a hidden prompt, never passed as a flag):
+omni config init --name <profile> --endpoint https://<org>.omniapp.co --auth api-key
+```
+
+> The API key is **never** accepted as a command-line flag — that would leak the secret into shell history and process listings. `omni config init` always reads it from a hidden prompt; there is no `--api-key` flag.
 
 Base URL and token are resolved in this order (highest wins):
 1. `--base-url` / `--token` flags on the command
 2. `OMNI_BASE_URL` / `OMNI_API_TOKEN` environment variables
-3. Active profile's `apiEndpoint` / `apiKey`
+3. Active profile's `apiEndpoint` / `apiKey` (or OAuth token)
+
+### Authenticating from an agent session
+
+`omni config login [profile]` runs an **OAuth 2.1 authorization-code flow with PKCE**: it starts a localhost callback server, opens the user's browser to the Omni authorization page, and **blocks for up to ~2 minutes** waiting for the redirect. `omni config init --auth oauth` does the same as part of profile creation. Tokens are stored in the profile and refresh automatically.
+
+A headless agent **cannot** complete this flow itself — it can't click through the browser consent, and the call blocks. Handle missing auth like this:
+
+1. **Detect it.** `omni whoami whoami` (or any call) failing with **401** or **403 `Invalid bearer token`** means the active profile isn't authenticated (see the preflight table below).
+2. **Default — hand off to the user.** Ask them to authenticate, then continue. In a Claude Code session the `!` prefix runs the command in-session so its output lands in the conversation:
+   ```bash
+   ! omni config login <profile>
+   ```
+   Do **not** run `config login` autonomously by default — it blocks on a browser consent the agent can't complete, and in a headless/CI session there is no browser, so it times out after ~2 minutes.
+3. **Exception — local interactive machine.** When you're certain the session is on the user's own machine with a browser, the agent *may* run `omni config login <profile>` directly (it opens the user's browser); the user still completes the consent. Never do this in headless/CI.
+
+### Preflight: verify CLI capability, auth, and permissions (`whoami`)
+
+`omni whoami whoami` doubles as the capability gate and the auth check — run it first and branch on the outcome:
+
+```bash
+omni whoami whoami                       # current identity, API-key scope, org role, per-model roles
+omni whoami whoami --modelid <id1,id2>   # scope rolesByModel to specific models
+```
+
+| Outcome | Meaning | Action |
+|---|---|---|
+| exit ≠ 0, stderr `unknown command "whoami"` | CLI predates 1.0.7 — no `whoami`, OAuth login, or `--schema` | Ask the user to update the CLI (see Installation above) |
+| exit ≠ 0, error `HTTP 401` or `403 "Invalid bearer token"` | The credential is missing, expired, or rejected | Hand off to OAuth login (see *Authenticating from an agent session* above) |
+| exit 0, identity JSON | Authenticated and capable | Proceed — read `role` / `rolesByModel` to decide whether an action is permitted *before* attempting it |
+
+Both failure modes exit non-zero, so **branch on the message, not just the exit code**. A `403` whose message is a *permissions* error (not `Invalid bearer token`) means you're authenticated but lack access — that's not an auth-handoff case. `whoami` is **self-scoped and available to non-admins**, so this works for any profile.
+
+**Prefer this capability probe over comparing `omni --version`.** Custom and dev builds (e.g. `local-prs-…`) and `install.sh`-from-`main` binaries carry the features without a release version, so a strict semver gate would reject a perfectly capable CLI. The same idiom guards other version-sensitive features — e.g. `omni documents v2-get --help >/dev/null 2>&1 || echo "CLI too old for the v2 documents API"`.
 
 ## Command Pattern
 
@@ -67,6 +114,27 @@ omni agent-help                    # Agent-oriented guide with common workflows
 omni --help                        # List all command groups
 omni <group> --help                # List operations in a group
 omni <group> <operation> --help    # Show flags and positional args
+```
+
+### Discovering request body shapes
+
+Any command that takes a request body accepts `--schema`. It prints the body's resolved JSON schema (field types, descriptions, enums, formats, required fields) **plus a filled-in example**, then exits — no API call, no token required. Use it instead of guessing the JSON for `--body`.
+
+```bash
+omni query run --schema                    # schema + example for the query body
+omni ai generate-query --schema --compact  # compact, good for piping to jq
+```
+
+The output is `{ method, path, required, body: <JSON schema>, example: <filled body> }`. `--help` tells you *that* a body is required; `--schema` tells you its *shape*.
+
+Two companion flags keep large schemas manageable (e.g. `documents v2-create`):
+
+- `--depth N` caps nesting (default 8); `--depth 1` is a top-level overview.
+- `--field PATH` drills into a dotted path, auto-descending arrays and maps.
+
+```bash
+omni documents v2-create --schema --depth 1                        # top-level keys only
+omni documents v2-create --schema --field queryPresentations.data  # just the tiles map
 ```
 
 ## Output

--- a/rules/omni-api-conventions.mdc
+++ b/rules/omni-api-conventions.mdc
@@ -17,7 +17,7 @@ curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | s
 
 Pre-built binaries for macOS (amd64/arm64), Linux (amd64/arm64), and Windows (amd64) are available on the [GitHub Releases page](https://github.com/exploreomni/cli/releases).
 
-> OAuth login (`omni config login`), the `whoami` command, and the `--schema` body-discovery flag require **omni CLI ≥ 1.0.7**. Check with `omni --version`; if a command errors with "unknown command", the binary is too old — ask the user to update it.
+> OAuth login (`omni config login`), the `whoami` command, and the `--schema` body-discovery flag require **omni CLI ≥ 1.0.7**. Don't gate on `omni --version` — custom/dev builds (e.g. `local-prs-…`) and `install.sh`-from-`main` binaries carry the features without a release version, so a semver check would reject a capable CLI. Instead probe capability: if a command errors with "unknown command", the binary is too old — ask the user to update it. (See the `whoami` preflight below.)
 
 ## Authentication
 
@@ -120,12 +120,14 @@ omni <group> <operation> --help    # Show flags and positional args
 
 Any command that takes a request body accepts `--schema`. It prints the body's resolved JSON schema (field types, descriptions, enums, formats, required fields) **plus a filled-in example**, then exits — no API call, no token required. Use it instead of guessing the JSON for `--body`.
 
+`--schema` is the **source of truth** for field-level body detail. Where a skill or reference doc hardcodes a `--body` shape, treat it as a worked example or a carrier for behavioral gotchas (merge semantics, stringify errors, ignored flags) — not an exhaustive field list. When the doc and `--schema` disagree on which fields exist or are required, `--schema` wins.
+
 ```bash
 omni query run --schema                    # schema + example for the query body
 omni ai generate-query --schema --compact  # compact, good for piping to jq
 ```
 
-The output is `{ method, path, required, body: <JSON schema>, example: <filled body> }`. `--help` tells you *that* a body is required; `--schema` tells you its *shape*.
+The output is `{ method, path, body: <JSON schema>, example: <filled body> }`, plus a top-level `required` array when the body has required fields (omitted when it has none). `--help` tells you *that* a body is required; `--schema` tells you its *shape*.
 
 Two companion flags keep large schemas manageable (e.g. `documents v2-create`):
 

--- a/skills/omni-admin/SKILL.md
+++ b/skills/omni-admin/SKILL.md
@@ -22,7 +22,12 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 omni config show
 # If multiple profiles exist, ask the user which to use, then switch:
 omni config use <profile-name>
+
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth**. If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 If no CLI profile exists but the environment provides credentials, pass them explicitly:
 
@@ -38,6 +43,7 @@ omni schedules --help        # Schedule operations
 omni connections --help      # Connection management
 omni documents --help        # Document permissions
 omni folders --help          # Folder permissions
+omni scim users-create --schema   # Print any body command's JSON schema + filled example (no token)
 ```
 
 > **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped).

--- a/skills/omni-admin/SKILL.md
+++ b/skills/omni-admin/SKILL.md
@@ -69,6 +69,8 @@ omni connections connection-environments-list
 
 ## User Management (SCIM 2.0)
 
+> The `--body` blocks below are worked examples. For the authoritative field list (types, required, enums), run the command with `--schema` — e.g. `omni scim users-create --schema` — rather than relying on these shapes to be exhaustive.
+
 ```bash
 # List users
 omni scim users-list

--- a/skills/omni-ai-eval/SKILL.md
+++ b/skills/omni-ai-eval/SKILL.md
@@ -30,7 +30,12 @@ omni ai-eval --help >/dev/null 2>&1 || echo "ERROR: 'omni ai-eval' missing — u
 omni config show
 # If multiple profiles exist, ask the user which to use:
 omni config use <profile-name>
+
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth**. If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 You also need the **model ID** of a shared model to evaluate. Evals require at least **Querier** access on that model, and at least one topic optimized for AI. See the [Evals guide](https://docs.omni.co/ai/evals) for concepts and prompt-set best practices.
 
@@ -42,7 +47,7 @@ You also need the **model ID** of a shared model to evaluate. Evals require at l
 | **Eval run** | Executes a prompt set against a model branch (or `main`). Each prompt runs as a full async agentic AI job (the same engine as production Blobby), then the accuracy judge scores the result. |
 | **Accuracy judge** | A fixed judge model that reads the evaluated AI's full conversation and returns a **pass/fail** verdict per prompt, plus confidence and a rationale. It targets high-impact analysis errors (hallucinations, date/time filtering, row-limit handling, mental math, period-over-period mistakes, wrong topic). It does **not** grade wording or formatting. |
 
-All commands accept `-o json` (or `--compact`) to force structured output for parsing, and `--profile <name>` / `--branch-id` style global flags. Run `omni ai-eval <command> --help` for the full flag list.
+All commands accept `-o json` (or `--compact`) to force structured output for parsing, and `--profile <name>` / `--branch-id` style global flags. Run `omni ai-eval <command> --help` for the full flag list. For commands that take a `--body` (e.g. `prompt-sets-create`), run them with `--schema` to print the body's JSON schema and a filled example instead of guessing the JSON.
 
 ## Step 1 — Build a prompt set
 

--- a/skills/omni-ai-optimizer/SKILL.md
+++ b/skills/omni-ai-optimizer/SKILL.md
@@ -22,7 +22,12 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 omni config show
 # If multiple profiles exist, ask the user which to use, then switch:
 omni config use <profile-name>
+
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth**. If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 Requires **Modeler** or **Connection Admin** permissions.
 

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -55,14 +55,20 @@ omni documents v2-get --help >/dev/null 2>&1 || echo "ERROR: CLI is too old for 
 omni config show
 # If multiple profiles exist, ask the user which to use, then switch:
 omni config use <profile-name>
+
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth**. If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 ## Discovering Commands
 
 ```bash
-omni documents --help           # Document operations (v2-* + lifecycle)
-omni dashboards --help          # Dashboard downloads
-omni models yaml-create --help  # Writing model YAML
+omni documents --help              # Document operations (v2-* + lifecycle)
+omni dashboards --help             # Dashboard downloads
+omni models yaml-create --help     # Writing model YAML
+omni documents v2-create --schema  # Body schema + example (add --depth 1 for an overview, --field PATH to drill in)
 ```
 
 > **Tip**: Use `-o json` to force structured output for programmatic parsing, or `-o human` for readable tables. The default is `auto` (human in a TTY, JSON when piped). `--compact` strips indentation for piping.

--- a/skills/omni-content-builder/references/documents-v2.md
+++ b/skills/omni-content-builder/references/documents-v2.md
@@ -21,6 +21,8 @@ The `omni documents v2-*` commands are the **only** surface for creating, readin
 
 ## Envelope
 
+The annotated shapes below exist for the **gotchas** — the field-level detail (every key, its type, which are required) is authoritative from the CLI itself: `omni documents v2-create --schema` (`--depth 1` for a top-level overview, `--field queryPresentations.data` to drill into a tile). When this doc and `--schema` disagree on a field, `--schema` wins; the prose here is for the behaviors `--schema` can't express.
+
 ```jsonc
 {
   "modelId": "<SHARED model id>",          // create-only; server mints a per-doc workbook model

--- a/skills/omni-content-explorer/SKILL.md
+++ b/skills/omni-content-explorer/SKILL.md
@@ -20,7 +20,12 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 omni config show
 # If multiple profiles exist, ask the user which to use, then switch:
 omni config use <profile-name>
+
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth**. If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 ## Discovering Commands
 

--- a/skills/omni-embed/SKILL.md
+++ b/skills/omni-embed/SKILL.md
@@ -27,8 +27,13 @@ omni config show
 # If multiple profiles exist, ask the user which to use, then switch:
 omni config use <profile-name>
 
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
+
 export OMNI_EMBED_SECRET="your-embed-secret"   # Admin → Embed (for URL signing)
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth** (separate from the embed secret below). If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 The embed secret is found in **Admin → Embed** in your Omni instance. Do not assume
 `OMNI_BASE_URL` is the embed host: CLI/API URLs often use `.omniapp.co`, custom

--- a/skills/omni-integrations/.claude-plugin/plugin.json
+++ b/skills/omni-integrations/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-integrations",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
   "author": {
     "name": "Omni Analytics",

--- a/skills/omni-integrations/.cursor-plugin/plugin.json
+++ b/skills/omni-integrations/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-integrations",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
   "author": {
     "name": "Omni Analytics",

--- a/skills/omni-integrations/skills/omni-to-databricks-metric-views/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-databricks-metric-views/SKILL.md
@@ -24,7 +24,12 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 omni config show
 # If multiple profiles exist, ask the user which to use, then switch:
 omni config use <profile-name>
+
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth**. If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 ```bash
 # Databricks CLI — verify installed and list configured profile names

--- a/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
@@ -22,7 +22,12 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 omni config show
 # If multiple profiles exist, ask the user which to use, then switch:
 omni config use <profile-name>
+
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth**. If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 ---
 

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -22,7 +22,12 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 omni config show
 # If multiple profiles exist, ask the user which to use, then switch:
 omni config use <profile-name>
+
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth**. If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 You need **Modeler** or **Connection Admin** permissions. Add `-o json` to any command to force structured output for parsing (default `auto` is human in a TTY, JSON when piped).
 
@@ -67,8 +72,9 @@ See `references/schema-refresh.md` for when to trigger, what it does and its sid
 ## Discovering Commands
 
 ```bash
-omni models --help              # List all model operations
-omni models yaml-create --help  # Show flags for writing YAML
+omni models --help                # List all model operations
+omni models yaml-create --help    # Show flags for writing YAML
+omni models yaml-create --schema  # Print the body's JSON schema + a filled example (no token)
 ```
 
 ## Safe Development Workflow

--- a/skills/omni-model-explorer/SKILL.md
+++ b/skills/omni-model-explorer/SKILL.md
@@ -24,7 +24,12 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 omni config show
 # If multiple profiles exist, ask the user which to use, then switch:
 omni config use <profile-name>
+
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth**. If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 API keys: Settings > API Keys (Organization Admin) or User Profile > Manage Account > Generate Token (Personal Access Token).
 

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -22,7 +22,12 @@ command -v omni >/dev/null || echo "ERROR: Omni CLI is not installed."
 omni config show
 # If multiple profiles exist, ask the user which to use, then switch:
 omni config use <profile-name>
+
+# Confirm the active profile is authenticated and inspect your permissions:
+omni whoami whoami
 ```
+
+> **Auth**: a profile authenticates with an **API key** or **OAuth**. If `whoami` (or any call) returns **401**, hand off — ask the user to run `! omni config login <profile>` (OAuth 2.1 browser flow; it blocks ~2 min on the browser). Don't run `config login` yourself in a headless/CI session (no browser → timeout); on a local interactive machine you *may*. See the **`omni-api-conventions`** rule for profile setup (`omni config init --auth oauth`) and discovering request-body shapes with `--schema`.
 
 You also need a **model ID** and knowledge of available **topics and fields**.
 
@@ -31,6 +36,7 @@ You also need a **model ID** and knowledge of available **topics and fields**.
 ```bash
 omni query --help              # List query operations
 omni query run --help          # Show flags for running a query
+omni query run --schema        # Print the body's JSON schema + a filled example (no token)
 omni ai --help                 # AI-powered query generation
 ```
 


### PR DESCRIPTION
## Summary

Aligns the Omni CLI guidance in these skills with three CLI PRs shipped in **omni CLI 1.0.7** — exploreomni/cli#64, exploreomni/cli#65, exploreomni/cli#66. The throughline: **authenticating from an agent session** and **discovering command inputs without guessing**.

- **#64** surfaces `omni whoami whoami` — a self-scoped identity + permission check.
- **#65** removes `--api-key` from `omni config init` (secret-in-argv leak); OAuth becomes the first-class non-interactive setup.
- **#66** adds `--schema` to every body-taking command (resolved JSON schema + a filled example, no token, no API call), plus `--depth N` / `--field PATH` for navigating large schemas.

## What changed

- **`rules/omni-api-conventions.mdc`** (shared source of truth):
  - New **"Authenticating from an agent session"** section — `omni config login` / `omni config init --auth oauth` run an OAuth 2.1 + PKCE flow that opens a localhost browser callback and **blocks ~2 minutes**, which a headless agent can't complete. Default is to **hand off** to the user (`! omni config login <profile>`); the agent may run it directly only on a local interactive machine, never in headless/CI. Tokens auto-refresh.
  - New **"Discovering request body shapes"** section for `--schema` (and the `--depth` / `--field` flags for large bodies like `documents v2-create`).
  - New **`whoami`** preflight that triages **CLI capability, auth, and permissions** in one call (`unknown command` → CLI predates 1.0.7, update it; `401`/`403 Invalid bearer token` → OAuth hand-off; identity JSON → proceed) — capability-based validation rather than a brittle `--version` semver gate, plus a minimum-version note (omni ≥ 1.0.7) in Installation.
  - Corrected setup: the API key is read from a hidden prompt — there is no `--api-key` flag.
- **All 11 skill prerequisites** — added an `omni whoami whoami` check + a compact auth note (API key vs OAuth, hand-off on 401, pointer to the rule for `--schema` and `omni config init --auth oauth`).
- **Body-authoring skills** (`omni-query`, `omni-content-builder`, `omni-model-builder`, `omni-admin`, `omni-ai-eval`) — concrete `--schema` examples in their discovery sections.
- **Agents** (`omni-analyst`, `omni-admin-agent`) — begin with a `whoami` + OAuth hand-off preflight.

## Versioning

- `omni-analytics` 1.4.3 → **1.5.0** and `omni-integrations` 1.1.1 → **1.2.0** (MINOR — new CLI capabilities surfaced).
- Also synced the Cursor manifests, which had drifted a patch behind the Claude manifests.

## Verification

Verified against **official omni CLI 1.0.7**:

- `omni whoami whoami` (with `--modelid`), `omni config login`, and `omni config init --auth oauth` exist; `config init` has no `--api-key` flag.
- `--schema` returns a real schema + example for `query run`, `documents v2-create`, `models yaml-create`, `scim users-create`, and `ai-eval prompt-sets-create`; `--depth` and `--field` drill into large schemas.
- All JSON manifests parse; markdown code-fences balanced.

## Deferred to a follow-up

Per discussion, the remaining CLI #64 surfaces are out of scope here: `ai-routines`, `ai credit-controls`, `ai-model-suggestions`, and the `documents v2-create containers:null` / `v2-get --pretty` side-effects.

> Note: CLI #64–66 shipped in omni CLI **1.0.7**; all guidance here was verified against that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wud1REEY2yaZGuETSWgsxr
