### PR TITLE
fix(ci): repair push and PR handling in security audit workflow

### DIFF
--- a/.github/workflows/update-skills-security-audits.yml
+++ b/.github/workflows/update-skills-security-audits.yml
@@ -211,13 +211,26 @@ jobs:
           branch="automation/skills-security-audits"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # The checkout is shallow and single-branch, so origin/$branch is absent
+          # locally and --force-with-lease would abort with "stale info".
+          git fetch --depth=1 origin "+refs/heads/$branch:refs/remotes/origin/$branch" || true
+
           git checkout -B "$branch"
           git add README.md
           git commit -m "Update skills.sh security audit status"
-          git push --force-with-lease origin "$branch"
+          if git rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null; then
+            git push --force-with-lease="$branch:$(git rev-parse "refs/remotes/origin/$branch")" origin "$branch"
+          else
+            git push origin "$branch"
+          fi
 
-          if gh pr view "$branch" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh pr edit "$branch" \
+          # Match only an open PR — gh pr view resolves to the last merged/closed
+          # PR for this branch, which would silently skip creating a new one.
+          open_pr="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$branch" --state open --json number --jq '.[0].number')"
+
+          if [ -n "$open_pr" ]; then
+            gh pr edit "$open_pr" \
               --repo "$GITHUB_REPOSITORY" \
               --title "Update skills.sh security audit status" \
               --body "Refreshes the README table from the public skills.sh security audit pages."


### PR DESCRIPTION
## Problem

The scheduled **Update skills.sh Security Audits** workflow has failed on every weekly run since late June (most recently [run 31339707348](https://github.com/exploreomni/omni-agent-skills/actions/runs/31339707348)). The scrape and README edit work fine; the job dies at the final push:

```
! [rejected] automation/skills-security-audits -> automation/skills-security-audits (stale info)
error: failed to push some refs
```

`actions/checkout` performs a shallow, single-branch clone, so the runner has no `origin/automation/skills-security-audits` remote-tracking ref. `--force-with-lease` with no baseline to compare against refuses the push.

## Changes

1. **Fetch the automation branch ref before pushing** so `--force-with-lease` has a real baseline, with a plain push fallback for the first run when the branch does not yet exist.
2. **Look up an open PR explicitly** instead of using `gh pr view "$branch"`. That command resolves to the most recent PR for the branch regardless of state — which is the *merged* PR #67. Once the push started working, the workflow would have taken the "edit existing PR" path and quietly re-titled the merged PR rather than opening a new one: a green run with no PR to show for it.

## Verification

YAML parses. The fix itself can only be exercised once this is on `main`, since the workflow triggers on `schedule` / `workflow_dispatch` from the default branch — worth a manual `workflow_dispatch` after merge to confirm before waiting for Sunday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)