### PR TITLE
docs(omni-analytics): sync skills with Omni CLI v1.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 4 context rules.",
-    "version": "1.7.0"
+    "version": "1.8.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.7.0",
+  "version": "1.8.0",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 4 context rules.",
-    "version": "1.7.0"
+    "version": "1.8.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "omni-analytics",
 
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {
     "name": "Omni Analytics",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.8.0] - 2026-08-20
+
+### omni-analytics
+
+_Summary: sync skills with Omni CLI v1.1.2 (new commands from the spec sync in [exploreomni/cli#71](https://github.com/exploreomni/cli/pull/71)). Command shapes verified against the released CLI via `--help`/`--schema`._
+
+**Added**
+- `omni-content-explorer` — free-text dashboard search via `omni content search --q --limit` as the first stop for "find the dashboard about X" (dashboards only; keywords match names, descriptions, query names, folder names, labels, and creator names), and atomic folder label management via `omni folders bulk-update-labels`.
+- `omni-admin` — new **AI Credits** section covering `omni ai credit-controls-*` (org, per-user, per-entity-group) and the new usage reads `credit-usage-users-read` / `credit-usage-entity-groups-read`, including the membership-id (not user-id) gotcha. New **Commit Signing Key Rotation** section for `connections dbt-rotate-signing-key` and `models git-rotate-signing-key`, with a confirm-before-rotating caution.
+- `omni-ai-optimizer` — new **AI Model Suggestions** section for the `omni ai-model-suggestions` command group (generate runs, list/ignore/restore/delete suggestions, enable/disable the schedule).
+- `omni-content-builder` — documented `documents v2-bind-query-model` / `v2-unbind-query-model` in the documents-v2 reference: the draft-scoped route for changing a tile's server-owned query-model binding, with the one-query-model-per-tile and LINKED-tile constraints.
+- `omni-model-builder` — documented `omni models branch-dbt-get` for dbt-connected models: reads the dbt environment a branch resolves to, with the default-environment fallback behavior.
+- `omni-admin` — new **Uploads** section covering the `omni uploads` group (list/create/delete plus the new `replace-data`, which swaps an upload's data while keeping its id — existing views and document tabs keep working, with a caution on column renames/removals).
+
 ## [1.7.0] - 2026-08-20
 
 ### omni-analytics

--- a/skills/omni-admin/SKILL.md
+++ b/skills/omni-admin/SKILL.md
@@ -67,6 +67,18 @@ omni connections schedules-list <connectionId>
 omni connections connection-environments-list
 ```
 
+### Commit Signing Key Rotation (CLI ≥ 1.1.2)
+
+Rotating invalidates the previous key — confirm with the user before running, and re-register the new public key wherever the old one was trusted.
+
+```bash
+# Rotate a connection's dbt commit signing key
+omni connections dbt-rotate-signing-key <connectionId>
+
+# Rotate a model's git commit signing key
+omni models git-rotate-signing-key <modelId>
+```
+
 ## User Management (SCIM 2.0)
 
 > The `--body` blocks below are worked examples. For the authoritative field list (types, required, enums), run the command with `--schema` — e.g. `omni scim users-create --schema` — rather than relying on these shapes to be exhaustive.
@@ -283,6 +295,49 @@ omni schedules recipients-get <scheduleId>
 
 omni schedules add-recipients <scheduleId> --body '{ "recipients": ["team@company.com"] }'
 ```
+
+## AI Credits
+
+Read and manage AI credit controls and usage (entity-group commands and usage reads require CLI ≥ 1.1.2). Org-level controls require the AI-admin permission; per-user controls and usage require manage-user-attributes; entity-group controls and usage require add/remove-users. Per-user and per-entity-group limits are also behind instance feature flags.
+
+```bash
+# Org-level credit controls
+omni ai credit-controls-get
+omni ai credit-controls-update --body '{ ... }'   # run with --schema for the body shape
+
+# Per-user and per-entity-group limits
+omni ai credit-controls-users-list
+omni ai credit-controls-users-update --body '{ ... }'
+omni ai credit-controls-entity-groups-list
+omni ai credit-controls-entity-groups-update --body '{ ... }'
+
+# Usage for the current billing period (reads work even when controls editing is disabled)
+omni ai credit-usage-users-read --body '{ "userIds": ["<membershipId>"] }'
+omni ai credit-usage-entity-groups-read --body '{ ... }'
+```
+
+> **Gotcha**: `credit-usage-users-read` takes **membership ids** (the user's membership in this organization), not base user ids — an unknown id 404s the whole request, naming the offending id. At most 1000 ids per request, no duplicates; users with no usage report 0.
+
+## Uploads
+
+Manage CSV/spreadsheet uploads (the files users upload to query alongside warehouse data). `create` and `replace-data` take the file via `--body` — run with `--schema` for the shape.
+
+```bash
+# List uploads — filter by connection or model, search by file name
+omni uploads list --connectionid <connectionId>
+omni uploads list --modelid <modelId> --searchterm "forecast" --type csv
+
+# Upload a CSV
+omni uploads create --body '{ ... }'   # see --schema
+
+# Replace the data behind an existing upload, keeping its id (CLI ≥ 1.1.2)
+omni uploads replace-data <uploadId> --body '{ ... }'
+
+# Delete an upload
+omni uploads delete <uploadId>
+```
+
+`replace-data` fully replaces the upload's data while its id stays stable — views and document tabs reference the upload by id, so they serve the new data with no model or document changes. Column renames/removals may break content referencing the old columns, so compare headers before replacing. For `uploads list --modelid`: shared models return connection uploads; workbook models return their own uploads.
 
 ## Verification After Changes
 

--- a/skills/omni-ai-optimizer/SKILL.md
+++ b/skills/omni-ai-optimizer/SKILL.md
@@ -460,6 +460,27 @@ Prioritize high-impact changes. Improve wording without changing semantics.
 
 > **Troubleshooting order** when Blobby answers wrong: confirm the topic is reachable (`ai_chat_topics`) → confirm the field is in context (workbook inspector; check it wasn't pruned or excluded by `ai_fields`/`hidden`) → then add or sharpen `ai_context`. Writing more context for a field the AI never received fixes nothing.
 
+## AI Model Suggestions
+
+Omni can generate model-improvement suggestions itself (CLI ≥ 1.1.2, `omni ai-model-suggestions --help`). Use these as a complement to the manual checklist above — review each suggestion before applying it:
+
+```bash
+# Kick off a generation run, then read it back
+omni ai-model-suggestions model-suggestions-generate <modelId>
+omni ai-model-suggestions model-suggestions-run-latest <modelId>
+omni ai-model-suggestions model-suggestions-run-get <modelId> <runId>
+
+# Work the suggestion list
+omni ai-model-suggestions model-suggestions-list <modelId>
+omni ai-model-suggestions model-suggestions-ignore <modelId> <suggestionId>
+omni ai-model-suggestions model-suggestions-restore <modelId> <suggestionId>
+omni ai-model-suggestions model-suggestions-delete <modelId> <suggestionId>
+
+# Recurring generation
+omni ai-model-suggestions model-suggestions-schedule-enable <modelId>
+omni ai-model-suggestions model-suggestions-schedule-disable <modelId>
+```
+
 ## Docs Reference
 
 - [Optimize models for Omni AI](https://docs.omni.co/modeling/develop/ai-optimization)

--- a/skills/omni-content-builder/references/documents-v2.md
+++ b/skills/omni-content-builder/references/documents-v2.md
@@ -12,6 +12,8 @@ The `omni documents v2-*` commands are the **only** surface for creating, readin
 | `v2-patch-draft <identifier>` | Create a draft (optionally branch-bound) and apply a patch |
 | `v2-patch-draft-by-identifier <identifier> <draftIdentifier>` | Patch an existing draft |
 | `v2-publish-draft <identifier>` | Publish the document's **main** draft |
+| `v2-bind-query-model <identifier> <draftIdentifier> <queryKey>` | Bind a tile to a query model on a draft (CLI ≥ 1.1.2) |
+| `v2-unbind-query-model <identifier> <draftIdentifier> <queryKey>` | Unbind a tile from its query model, keeping its query (CLI ≥ 1.1.2) |
 
 - Draft commands take the **document identifier first, then the draft identifier**: `<identifier> <draftIdentifier>`.
 - There is **no one-shot patch** — every edit is patch-draft → verify → publish-draft.
@@ -73,6 +75,8 @@ For anything non-trivial, write the body to a file and pass `--body "$(cat body.
 ### The server anchors tiles to the workbook model
 
 On create, the server mints a per-document **workbook** model extending the shared `modelId` you pass. Tile queries carry **no `modelId`** — reads never expose one, and a `modelId` or `model_extension_id` you send in a tile query is **silently rewritten** to the workbook model, so omit them. When you need the workbook model id (to write model YAML), read it from the draft's `workbookModelId` via `documents list-drafts` — and it **rotates**: each draft clones the workbook model (extensions carried along), and publishing swaps the document to the clone, so the id changes after **every** publish. Never cache it; read it fresh from `list-drafts` each time.
+
+Since the binding is server-owned on the PATCH surface, changing a tile's query-model binding goes through the dedicated draft-scoped commands (CLI ≥ 1.1.2): `v2-bind-query-model <identifier> <draftIdentifier> <queryKey>` (body carries the `queryModelId` — see `--schema`) and `v2-unbind-query-model` (no body; keeps the tile's query). The `queryModelId` must be a live query model layered on this draft's workbook model and not already bound to another tile — a query model is dedicated to a single query. A LINKED tile inherits its query model from its source and can't be bound directly. Because each draft re-clones its query models, bind against a draft you have already read.
 
 ## Tile (queryPresentation) shape
 

--- a/skills/omni-content-explorer/SKILL.md
+++ b/skills/omni-content-explorer/SKILL.md
@@ -39,8 +39,18 @@ omni folders --help     # Folder operations
 
 ## Known Issues & Safe Defaults
 
-- `omni content list` does not currently support a `--labels` filter. To find documents by label, use `omni documents list --include labels -o json`, paginate with `--cursor`, then filter records whose `labels` array contains the target label.
+- `omni content list` does not currently support a `--labels` filter. For dashboards, `omni content search --q <labelName>` matches labels. For an exhaustive by-label listing (including workbook-only documents), use `omni documents list --include labels -o json`, paginate with `--cursor`, then filter records whose `labels` array contains the target label.
 - Some dashboard exports can fail before a job is created, for example with `Cannot use 'in' operator to search for 'query_id' in ...`. If `omni dashboards download` returns an error and no job ID, do not call `download-status` or claim the export completed. Report the dashboard identifier, the exact API error, and that no downloadable job was created.
+
+## Searching Content
+
+For "find the dashboard about X", reach for free-text search first (CLI ≥ 1.1.2):
+
+```bash
+omni content search --q "revenue" --limit 25
+```
+
+`--q` keywords are matched against dashboard names, descriptions, query names, folder names, labels, and creator names. `--limit` caps results at 1–25. Each result carries `identifier`, `name`, `description`, `folderPath`, `tileNames`, `verified`, and a ready-made `url` — link the user straight to it. Search covers **dashboards only** — workbook-only documents don't surface here, so fall back to `omni content list` / `omni documents list` filtering when the target may not have a dashboard.
 
 ## Browsing Content
 
@@ -129,6 +139,10 @@ omni documents add-label <identifier> <labelName>
 
 # Remove label
 omni documents remove-label <identifier> <labelName>
+
+# Add/remove labels on a folder in one atomic call (CLI ≥ 1.1.2).
+# Labels must already exist in the organization.
+omni folders bulk-update-labels <folderId> --body '{ "add": ["Q1"], "remove": ["Draft"] }'
 ```
 
 ## Favorites

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -129,6 +129,8 @@ omni models yaml-create <modelId> --body '{
 
 > **⚠️ Editing an existing file = whole-file read-modify-write at its exact path.** `yaml-create` **replaces** a file's authored content (no field-by-field merge), so `yaml-get` it first, edit, and write the **complete** file back, or the other authored fields are dropped. `fileName` is the file's **exact path** (not a regex, unlike on read) — reuse the full-path key verbatim, folder prefix included (e.g. `MARTS/fct_ai_events.view`); a non-matching name doesn't error, it **silently creates a duplicate** at that path (`success: true`). (Schema base columns live in the schema layer, so they're unaffected.) To **inspect** a branch, `yaml-get` **without** `--filename` enumerates the whole model — `--mode extension` for just the branch's changed files (your deltas), `--mode combined` for the full composed model (schema + shared + branch); then drill into any file by its exact path.
 
+> **dbt-connected models**: `omni models branch-dbt-get <modelId> <branchName>` (CLI ≥ 1.1.2) reads the dbt environment a branch resolves to, including the dbt git branch it compiles against. A branch with no environment of its own resolves to the connection's default (production) environment, reported with `is_default_environment: true`.
+
 ### Step 2: Validate and Test
 
 Every YAML write must be validated and tested before merging — a field can be valid YAML yet produce wrong results or broken queries.


### PR DESCRIPTION
## Summary

- document the Omni CLI v1.1.2 command additions across content discovery, administration, AI optimization, document drafts, and model branches
- add complete uploads coverage and safe guidance for signing-key rotation and AI credit controls
- bump omni-analytics to 1.8.0 after PR #90 released 1.7.0

## Testing

- all five affected skills pass the skill structural validator
- all documented command shapes rechecked with Omni CLI 1.1.2 via `--help` and `--schema`
- live read-only checks passed for content search, uploads list, AI credit controls and usage, model suggestions, and dbt branch environment resolution
- `./evals/runner.sh omni-admin --preflight-only` passed
- `./evals/runner.sh omni-model-builder --preflight-only` passed
- repository-wide preflight is blocked by a pre-existing dirty Sales Performance dashboard fixture: expected only `Revenue by Month`, but also found `Total Revenue This Quarter`; no fixture reset was performed
- `git diff --check` passes