### PR TITLE
fix(model-builder): clarify topic-scoped cross-view field placement

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 4 context rules.",
-    "version": "1.9.0"
+    "version": "1.9.1"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.9.0",
+  "version": "1.9.1",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 4 context rules.",
-    "version": "1.9.0"
+    "version": "1.9.1"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "omni-analytics",
 
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {
     "name": "Omni Analytics",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.9.1] - 2026-09-03
+
+### omni-analytics
+
+**Fixed**
+- **`omni-model-builder` cross-view field placement** — clarifies that topic-scoped fields retain the requested `<view>.<field>` query namespace, and requires checking every topic that exposes the host view before placing a cross-view field in the global view file. Adds a regression eval for a measure stored under `views.order_items.measures` and queried as `order_items.revenue_per_user`.
+
 ## [1.9.0] - 2026-09-02
 
 ### omni-analytics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The versions documented here should match the published plugin versions in the a
 ### omni-analytics
 
 **Fixed**
-- **`omni-model-builder` cross-view field placement** — clarifies that topic-scoped fields retain the requested `<view>.<field>` query namespace, and requires checking every topic that exposes the host view before placing a cross-view field in the global view file. Adds a regression eval for a measure stored under `views.order_items.measures` and queried as `order_items.revenue_per_user`.
+- **`omni-model-builder` cross-view field placement** — clarifies that topic-scoped fields retain the requested `<view>.<field>` query namespace, and bases global-versus-topic placement on intended availability plus each topic's resolved join map. Documents the reproduced boundary: topics may inherit global relationships, while an explicit/frozen join map can omit a dependency and produce blocking `field_broken_in_topic` validation. Adds a topic-only regression eval for a measure stored under `views.order_items.measures` and queried as `order_items.revenue_per_user`.
 
 ## [1.9.0] - 2026-09-02
 

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -303,11 +303,11 @@ measures:
 
 ### Cross-View Fields in Views
 
-Avoid defining cross-view fields (dimensions or measures whose `sql` references `${other_view.field}`) directly in a view file. These fields depend on another view being joined, which is not guaranteed in every topic that includes this view. In topics where the referenced view isn't present, the field will be omitted — but more importantly, the model validator will throw errors for any topic that includes this view without also joining the referenced view. This can create a cascade of validator errors across topics that are otherwise valid but happen to include only a subset of the involved views.
+Cross-view fields (dimensions or measures whose `sql` references `${other_view.field}`) in a global view file are evaluated in every topic that exposes the host view. A global relationship can make the dependency reachable in topics that inherit the global join graph, but it does not override a topic's explicit/frozen `joins:` map. If that map omits the dependency, validation returns a blocking `field_broken_in_topic` issue and queries using the field fail to plan.
 
-**Placement follows dependency scope, not field namespace.** In the vast majority of cases, define a cross-view field in the topic's `views.<host_view>` block (see "Topic-Scoped View Definitions"), where the join context is explicit and controlled. The field remains queryable as `<host_view>.<field>`; topic scoping limits where it is available, not the namespace the user requested.
+**Placement follows intended availability and resolved join context, not field namespace.** Define the field in the topic's `views.<host_view>` block (see "Topic-Scoped View Definitions") when it is meaningful only in that topic or depends on a topic-specific, aliased, or frozen join. The field remains queryable as `<host_view>.<field>`; topic scoping limits where it is available, not the namespace the user requested.
 
-Only define a cross-view field in the view file itself after inspecting every topic that exposes the host view and confirming the referenced view is joined in each one. A global relationship alone does not prove both views are present in every topic; use the global view file only when the views are inseparable by design.
+Use the global view file when the field is universally meaningful and its dependency resolves unambiguously in every topic that exposes the host view. Before choosing, list those topics and inspect each resolved `get-topic` `join_via_map` — not only the global relationships file — then validate the branch and query at least one topic for each distinct join context. Topics without explicit joins may inherit a global relationship; topics with explicit joins may exclude it.
 
 ## Fallback: View Missing from yaml-get
 

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -305,9 +305,9 @@ measures:
 
 Avoid defining cross-view fields (dimensions or measures whose `sql` references `${other_view.field}`) directly in a view file. These fields depend on another view being joined, which is not guaranteed in every topic that includes this view. In topics where the referenced view isn't present, the field will be omitted — but more importantly, the model validator will throw errors for any topic that includes this view without also joining the referenced view. This can create a cascade of validator errors across topics that are otherwise valid but happen to include only a subset of the involved views.
 
-**In the vast majority of cases, cross-view fields should be defined in the topic's `views:` block** (see "Topic-Scoped View Definitions"), where the join context is explicit and controlled.
+**Placement follows dependency scope, not field namespace.** In the vast majority of cases, define a cross-view field in the topic's `views.<host_view>` block (see "Topic-Scoped View Definitions"), where the join context is explicit and controlled. The field remains queryable as `<host_view>.<field>`; topic scoping limits where it is available, not the namespace the user requested.
 
-Only define a cross-view field in the view file itself when you are certain the referenced view will always be joined in every topic that includes this view — for example, when the join is defined globally and the two views are inseparable by design.
+Only define a cross-view field in the view file itself after inspecting every topic that exposes the host view and confirming the referenced view is joined in each one. A global relationship alone does not prove both views are present in every topic; use the global view file only when the views are inseparable by design.
 
 ## Fallback: View Missing from yaml-get
 

--- a/skills/omni-model-builder/evals/evals.json
+++ b/skills/omni-model-builder/evals/evals.json
@@ -55,6 +55,19 @@
         "The agent reports validation warnings separately and does not claim they were caused by the deleted column unless validation or content-validator output identifies the missing table or column"
       ],
       "expected_skill": "omni-model-builder"
+    },
+    {
+      "id": "5",
+      "question": "Add a revenue_per_user measure to the order_items view, defined as order_items.total_revenue divided by users.count. Keep the field under order_items, and query it by users.country to verify it.",
+      "ground_truth": "Because the measure depends on users, it is defined under views.order_items.measures in a topic that joins users, not in the global order_items view file. It remains queryable as order_items.revenue_per_user. The agent confirms users is joined, validates the branch, and queries the topic by users.country.",
+      "expected_behavior": [
+        "The agent recognizes users.count as a cross-view dependency and does not define revenue_per_user in the global order_items view file",
+        "The measure is defined under views.order_items.measures in a topic that joins users, preserving the query namespace order_items.revenue_per_user",
+        "The agent confirms the users view is declared in the topic's joins before writing the cross-view measure",
+        "The ratio SQL safely handles a zero denominator, and the agent reads the YAML back to confirm field references survived serialization",
+        "The agent validates the branch and queries order_items.revenue_per_user grouped by users.country through the topic join path before asking about any merge"
+      ],
+      "expected_skill": "omni-model-builder"
     }
   ]
 }

--- a/skills/omni-model-builder/evals/evals.json
+++ b/skills/omni-model-builder/evals/evals.json
@@ -58,12 +58,12 @@
     },
     {
       "id": "5",
-      "question": "Add a revenue_per_user measure to the order_items view, defined as order_items.total_revenue divided by users.count. Keep the field under order_items, and query it by users.country to verify it.",
-      "ground_truth": "Because the measure depends on users, it is defined under views.order_items.measures in a topic that joins users, not in the global order_items view file. It remains queryable as order_items.revenue_per_user. The agent confirms users is joined, validates the branch, and queries the topic by users.country.",
+      "question": "Add a revenue_per_user measure to the order_items view, defined as order_items.total_revenue divided by users.count. Keep the field under order_items, but make it available only in the Order Items topic, and query it by users.country to verify it.",
+      "ground_truth": "Because the requested availability and users dependency are specific to the Order Items topic, the measure is defined under views.order_items.measures in that topic, not in the global order_items view file. It remains queryable as order_items.revenue_per_user. The agent confirms users is in the topic's resolved join map, validates the branch, and queries the topic by users.country.",
       "expected_behavior": [
-        "The agent recognizes users.count as a cross-view dependency and does not define revenue_per_user in the global order_items view file",
+        "The agent recognizes the requested topic-only availability and users.count dependency, and does not define revenue_per_user in the global order_items view file",
         "The measure is defined under views.order_items.measures in a topic that joins users, preserving the query namespace order_items.revenue_per_user",
-        "The agent confirms the users view is declared in the topic's joins before writing the cross-view measure",
+        "The agent confirms the users view is present in the topic's resolved join map before writing the cross-view measure",
         "The ratio SQL safely handles a zero denominator, and the agent reads the YAML back to confirm field references survived serialization",
         "The agent validates the branch and queries order_items.revenue_per_user grouped by users.country through the topic join path before asking about any merge"
       ],


### PR DESCRIPTION
## Summary

- clarify that topic-scoped fields retain their `<host_view>.<field>` query namespace
- choose global versus topic placement from intended availability and each topic's resolved join context
- document the reproduced boundary between inherited global joins and explicit/frozen topic join maps
- add a topic-only regression eval and bump `omni-analytics` to 1.9.1

## Why this belongs in `SKILL.md`

This is the decision rule the agent needs before choosing which YAML file to edit. Detailed examples remain in the reference. The change replaces existing guidance, keeps `SKILL.md` at 500 lines, and is only 34 words larger than `main`.

## Omni docs and live behavior

The public docs establish the primitives: [`joins`](https://docs.omni.co/modeling/topics/parameters/joins) declares which views are part of a topic; topic [`views`](https://docs.omni.co/modeling/topics/parameters/views) customizes fields only in that topic; [global relationships](https://docs.omni.co/modeling/relationships/index) are reusable across topics. Omni's AI docs search was internally inconsistent on the placement recommendation, so this PR does not rely on that synthesis alone.

A controlled branch test on the isolated skills eval model reproduced the actual boundary:

1. **Unfrozen topic, no explicit `joins:`** — inherited the global `order_items -> users` relationship; a global `order_items.experience_revenue_per_user` measure validated and planned successfully.
2. **Explicit/frozen join map omitting `users`** — the same global measure produced blocking `field_broken_in_topic`; a plan-only query failed because `users.count` was not joined.
3. **Topic-scoped measure in the joined topic** — validation returned only pre-existing warnings; the measure remained `order_items.experience_revenue_per_user`, compiled with `is_topic_scoped: true`, and was absent from the frozen topic.

This supports a broader rule than “cross-view always means topic-scoped”: use a global field when it is universally meaningful and resolves in every topic; use topic scope when availability or join semantics are topic-specific. Inspect resolved `get-topic.join_via_map`, not only the relationships file.

The temporary Omni experiment branch was deleted after the test.

## Validation

- `python3 -m json.tool` passed for the eval and all changed plugin manifests
- `git diff --check` passed
- refined eval case 5 preflight passed
- an earlier A/B run of case 5's less-explicit prompt showed with-skill reward 1.0 versus baseline 0.8; the case now explicitly requests topic-only availability so it does not encode the blanket rule this live experiment disproved

No merge was performed.