### PR TITLE
fix(omni-to-snowflake-semantic-view): match relationships to exact hierarchy edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 Since 1.11.0 both plugins share one version, held in `versions.json` and stamped into the manifests by CI. Entries below 1.11.0 use the older scheme, where the heading number belonged to whichever plugin that release was for — which is why those version numbers do not read in order.
 
+## [1.11.1] - 2026-09-10
+
+### omni-integrations
+
+**Fixed**
+- **`omni-to-snowflake-semantic-view` matches relationships to exact join-hierarchy edges.** The skill previously could match a `relationships.yaml` entry by view name alone, which — since that file is model-wide and can hold multiple relationships touching the same view — could silently pick the wrong one and skip an intermediate table (e.g. joining a child view straight to a grandparent instead of through its actual parent). It now requires an exact `(parent, child)` match per hierarchy edge, respects `reversible` before using a reversed entry, always orients output relationships child → parent, and stops to ask the user on no match or an ambiguous match.
+
 ## [1.11.0] - 2026-09-10
 
 _Both plugins move to a single shared version with this release. They ship from

--- a/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
@@ -183,7 +183,7 @@ joins:
       ecomm__distribution_centers: {}   # joins to PRODUCTS
 ```
 
-> Skip any view that is a derived table (CTE defined in SQL in Omni). These have no physical Snowflake table to reference.
+> Skip any view that is a derived table (CTE defined in SQL in Omni). These have no physical Snowflake table to reference. If another view is nested *beneath* a skipped derived table, see Step 5 — its hierarchy edge names a parent with no physical table, so it can't be matched to a `relationships.yaml` entry either.
 
 #### Primary keys
 
@@ -250,12 +250,12 @@ Each entry in `relationships.yaml` looks like:
 
 The `on_sql` field tells you the join columns. Extract the column names to populate `relationship_columns` in the output.
 
-> ⚠️ **Critical — match relationships to exact hierarchy edges, not view-name pairs:** `relationships.yaml` is model-wide — it commonly contains multiple relationships that reference the same view (e.g. both an `account ↔ contacts` relationship AND a separate `opportunity ↔ contacts` "primary contact" relationship). Never search `relationships.yaml` for "any entry that mentions view X" — this can silently pick the wrong relationship and skip an intermediate table in the hierarchy.
+> ⚠️ **Critical — match relationships to exact hierarchy edges, not view-name pairs:** `relationships.yaml` is model-wide — it commonly contains multiple relationships that reference the same view, including a join between the same two views in either direction with a different `on_sql`. Never search `relationships.yaml` for "any entry that mentions view X" — this can silently pick the wrong relationship and skip an intermediate table in the hierarchy. For example, in the Step 3 tree, `demo__product_images` is nested under `ecomm__products` — the relationship you need is `ecomm__products ↔ demo__product_images`, not any entry that happens to reference `demo__product_images` from a different view.
 >
-> Instead:
-> 1. From the indentation tree in Step 3, enumerate every `(parent, child)` edge exactly as nested (e.g. if `contacts` is indented under `account`, the edge is `(account, contacts)` — **not** `(base_view, contacts)`).
-> 2. For each edge, find the `relationships.yaml` entry whose `join_from_view`/`join_to_view` pair matches that **exact** parent/child pair (in either direction).
-> 3. If no entry matches that exact pair, or more than one entry matches ambiguously, **stop and ask the user** which relationship to use rather than substituting a different entry that happens to reference the same view name.
+> 1. From the indentation tree in Step 3, enumerate every `(parent, child)` edge exactly as nested (e.g. `(ecomm__products, demo__product_images)` — **not** `(base_view, demo__product_images)`).
+> 2. For each edge, find the `relationships.yaml` entry whose `join_from_view`/`join_to_view` pair matches that exact parent/child pair, checked in either direction.
+> 3. **Check `reversible` before using a reversed match.** If the matching entry is already written child → parent, use it as-is. If it's written parent → child (reversed relative to the hierarchy edge), only use it if `reversible: true` — otherwise it's not a valid match. Snowflake relationships are directional (many-to-one, child → parent), so regardless of how the entry is written, emit the output oriented **child → parent**: `left_table`/`left_column` is the child (foreign key), `right_table`/`right_column` is the parent (primary key).
+> 4. If no entry matches that exact pair (per steps 2–3), or more than one entry matches ambiguously, **stop and ask the user** which relationship to use rather than substituting a different entry that happens to reference the same view name. This also covers a view nested beneath a *skipped* derived table (Step 3) — its edge names a parent with no physical table, so nothing can match it. Don't silently drop the view or reparent it to the base view; stop and ask.
 
 **Available relationship parameters:**
 

--- a/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
+++ b/skills/omni-integrations/skills/omni-to-snowflake-semantic-view/SKILL.md
@@ -250,6 +250,13 @@ Each entry in `relationships.yaml` looks like:
 
 The `on_sql` field tells you the join columns. Extract the column names to populate `relationship_columns` in the output.
 
+> ⚠️ **Critical — match relationships to exact hierarchy edges, not view-name pairs:** `relationships.yaml` is model-wide — it commonly contains multiple relationships that reference the same view (e.g. both an `account ↔ contacts` relationship AND a separate `opportunity ↔ contacts` "primary contact" relationship). Never search `relationships.yaml` for "any entry that mentions view X" — this can silently pick the wrong relationship and skip an intermediate table in the hierarchy.
+>
+> Instead:
+> 1. From the indentation tree in Step 3, enumerate every `(parent, child)` edge exactly as nested (e.g. if `contacts` is indented under `account`, the edge is `(account, contacts)` — **not** `(base_view, contacts)`).
+> 2. For each edge, find the `relationships.yaml` entry whose `join_from_view`/`join_to_view` pair matches that **exact** parent/child pair (in either direction).
+> 3. If no entry matches that exact pair, or more than one entry matches ambiguously, **stop and ask the user** which relationship to use rather than substituting a different entry that happens to reference the same view name.
+
 **Available relationship parameters:**
 
 | Parameter | Description |

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,4 @@
 {
   "//": "Single source of truth for the plugin version. Both plugins ship from this repo at the same commit and share one version; see CONTRIBUTING.md.",
-  "version": "1.11.0"
+  "version": "1.11.1"
 }


### PR DESCRIPTION
## Summary
- `relationships.yaml` is model-wide and can contain multiple relationships touching the same view (e.g. an `account ↔ contacts` relationship and a separate `opportunity ↔ contacts` "primary contact" relationship).
- The skill previously matched relationships by view name alone, which could silently pick the wrong relationship and skip an intermediate table in the join hierarchy — e.g. producing `OPPORTUNITIES → CONTACTS` directly instead of the correct `ACCOUNT → CONTACTS` implied by the topic's join nesting.
- Step 5 now requires matching each join-hierarchy `(parent, child)` edge to the `relationships.yaml` entry whose `join_from_view`/`join_to_view` matches that exact pair, and to stop and ask the user when there's no match or an ambiguous match.

## Test plan
- [ ] Re-run the skill against a topic with a multi-level join hierarchy where a leaf view has more than one relationship defined against it in `relationships.yaml`, and confirm the generated relationship uses the correct intermediate table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)