### PR TITLE
docs(omni-analytics): sync skills with Omni CLI v1.2.1 and v1.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 4 context rules.",
-    "version": "1.9.1"
+    "version": "1.10.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.9.1",
+  "version": "1.10.0",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 4 context rules.",
-    "version": "1.9.1"
+    "version": "1.10.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "omni-analytics",
 
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {
     "name": "Omni Analytics",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.10.0] - 2026-09-10
+
+### omni-analytics
+
+_Summary: sync skills with Omni CLI v1.2.1 and v1.2.2. 1.2.2 adds the **alpha app sub-resource** on documents v2 (8 commands), `models delete`, and `ai job-feedback-submit`, and **removes** the v1 document write endpoints (`documents update` / `documents put`); 1.2.1 adds update notifications. Every command and body shape below was probed against the released 1.2.2 binary with `--help` / `--schema`._
+
+**Added**
+- **`omni-content-builder` — apps (alpha).** A document can now carry HTML content in place of a dashboard. New *Apps* section in `references/documents-v2.md` covering the eight `documents v2-*-app` commands, the `app` slice on `v2-create` (mutually exclusive with `containers` / `controls` / `settings`), the dashboard-XOR-app rule, `PUT`-creates / `PATCH`-doesn't and the differing 409 gates on `v2-patch-app` (no app on the draft) versus `v2-patch-app-auto-draft` (no *published* app), last-write-wins on `PUT` versus all-or-nothing content-addressed `htmlEdits` on `PATCH` — which detects a stale read but is **not** concurrency safety — the 2 MiB HTML cap, the `allowCreateApps` / org-toggle creation gates behind an otherwise-bare 403, and the silent-failure mode that matters most: **writes never reject on host policy**, so an app pulling a disallowed CDN host returns 200 with a non-blocking `warnings` entry and then renders blank under the CSP. Per-command detail is left to `--help` / `--schema`, which carry it verbatim from the spec.
+- **`omni-model-builder` — `models delete`.** Trashes a SHARED or shared-extension model together with the workbooks, dashboards, and child extension models built on it; requires Connection Admin. Flagged for user confirmation because of that blast radius, and distinguished from `models delete-branch`.
+- **`omni-query` — `ai job-feedback-submit`.** Thumbs up/down (plus optional comment) on a finished AI job, with the `COMPLETE`/`FAILED`-only 409 gate and the append-only, never-read-back caveat.
+- **`omni-api-conventions` rule — `omni update check`** (CLI ≥ 1.2.1) as the follow-up when a capability probe fails: it reports `currentVersion` / `latestVersion` and an `upgrade` object carrying both the `brew` and `install.sh` commands. Documented as *offer the user both* — it does no install-method detection — with the `v`-prefix mismatch that makes a naive string compare of the two versions never match.
+
+**Fixed**
+- **The v1 document write commands are gone.** `PATCH`/`PUT /api/v1/documents/{identifier}` were removed from the API, so `documents update` / `documents put` no longer exist in the CLI. `omni-content-builder` (SKILL.md and `references/documents-v2.md`) told agents "never fall back to v1 `create`/`get`/`put`/`update`" — the two removed verbs are dropped from that list, since naming a nonexistent command as a tempting fallback is worse than not naming it. `omni-query`'s `references/job-result-to-presentation.md` pointed at `omni documents create` "or a dashboard PUT" and now points at `v2-create` / `v2-patch-draft`.
+
 ## [1.9.1] - 2026-09-03
 
 ### omni-analytics

--- a/rules/omni-api-conventions.mdc
+++ b/rules/omni-api-conventions.mdc
@@ -91,7 +91,7 @@ omni whoami whoami --model-id <id1,id2>   # scope rolesByModel to specific model
 
 Both failure modes exit non-zero, so **branch on the message, not just the exit code**. A `403` whose message is a *permissions* error (not `Invalid bearer token`) means you're authenticated but lack access — that's not an auth-handoff case. `whoami` is **self-scoped and available to non-admins**, so this works for any profile.
 
-**Prefer this capability probe over comparing `omni --version`.** Custom and dev builds (e.g. `local-prs-…`) and `install.sh`-from-`main` binaries carry the features without a release version, so a strict semver gate would reject a perfectly capable CLI. The same idiom guards other version-sensitive features — e.g. `omni documents v2-get --help >/dev/null 2>&1 || echo "CLI too old for the v2 documents API"`.
+**Prefer this capability probe over comparing `omni --version`.** Custom and dev builds (e.g. `local-prs-…`) and `install.sh`-from-`main` binaries carry the features without a release version, so a strict semver gate would reject a perfectly capable CLI. The same idiom guards other version-sensitive features — e.g. `omni documents v2-get --help >/dev/null 2>&1 || echo "CLI too old for the v2 documents API"`. When a probe does fail, `omni update check` (CLI ≥ 1.2.1) reports `currentVersion` / `latestVersion` and an `upgrade` object carrying **both** a `homebrew` and an `other` (`install.sh`) command — it does not detect how this binary was installed, so offer the user both rather than picking one. Note `latestVersion` is `v`-prefixed and `currentVersion` is not, so don't compare them as strings — read `updateAvailable`.
 
 ## Command Pattern
 

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -9,7 +9,7 @@ Create, update, and manage Omni documents and dashboards programmatically via th
 
 > **Tip**: Use `omni-model-explorer` to understand available fields and `omni-content-explorer` to find existing dashboards to modify or learn from.
 
-Documents are created and edited through the **v2 documents API** (`omni documents v2-*`) — an explicit envelope of `queryPresentations`, `controls`, `containers`, and `settings`, edited through a **draft → publish** flow. This is the only path for building, reading, or changing a document — never fall back to the v1 `documents create`/`get`/`put`/`update` commands. A few document-management operations (list, delete, move, duplicate, downloads) have no v2 form; see [Commands](#commands) below.
+Documents are created and edited through the **v2 documents API** (`omni documents v2-*`) — an explicit envelope of `queryPresentations`, `controls`, `containers`, and `settings`, edited through a **draft → publish** flow. This is the only path for building, reading, or changing a document — never fall back to the v1 `documents create`/`get` commands (v1 `put`/`update` were removed in CLI 1.2.2). A few document-management operations (list, delete, move, duplicate, downloads) have no v2 form; see [Commands](#commands) below.
 
 ## Known Issues & Safe Defaults
 
@@ -75,7 +75,7 @@ omni documents v2-create --schema  # Body schema + example (add --depth 1 for an
 
 ## Commands
 
-**Build and edit documents with the `documents v2-*` commands — always.** There is no situation where you reach back to the v1 `documents create`/`get`/`put`/`update` path to build, read, or change a document; the v2 draft flow covers all of it.
+**Build and edit documents with the `documents v2-*` commands — always.** There is no situation where you reach back to the v1 `documents create`/`get` path to build, read, or change a document; the v2 draft flow covers all of it.
 
 | Operation | Command |
 |---|---|
@@ -84,6 +84,7 @@ omni documents v2-create --schema  # Body schema + example (add --depth 1 for an
 | Edit document (tiles, controls, layout, settings, rename) | `documents v2-patch-draft` (+ `v2-patch-draft-by-identifier`) |
 | Get the workbook model ID | `documents list-drafts` → `workbookModelId` (open a draft first) |
 | Publish a draft | `documents v2-publish-draft` |
+| Read or edit an **app** (HTML instead of a dashboard) | `documents v2-*-app` — alpha, CLI ≥ 1.2.2; see [references/documents-v2.md](references/documents-v2.md) |
 
 A handful of **document-management** operations have no v2 form — they aren't alternatives to the v2 build path, just the only command for that job: `documents list` / `list-drafts` (find documents and drafts), `documents discard-draft` (abandon a draft), `documents delete` / `move` / `duplicate` (lifecycle), `documents get-queries` (extract a tile's runnable query for validation), `dashboards download` / `download-status`, and `models yaml-create` / `validate` (model writes).
 

--- a/skills/omni-content-builder/SKILL.md
+++ b/skills/omni-content-builder/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: omni-content-builder
-description: Create, update, and manage Omni Analytics documents and dashboards programmatically — document lifecycle, drafts, tiles, visualizations, filters, controls, and layouts — using the Omni CLI. Use this skill whenever someone wants to build a dashboard, create a workbook or document, add tiles or charts, configure dashboard filters or controls, set up a KPI view, lay out or rearrange tiles and pages, edit a dashboard as a draft and publish it, change dashboard settings, rename/move/duplicate/delete a dashboard, or modify dashboard-level model customizations like workbook-specific joins or fields — including casual phrasings like "make a dashboard for…", "add a chart to…", or "clean up this dashboard's layout" that don't name the skill. For running a query or pulling metrics use omni-query; for adding a field to the shared model use omni-model-builder.
+description: Create, update, and manage Omni Analytics documents and dashboards programmatically — document lifecycle, drafts, tiles, visualizations, filters, controls, and layouts — using the Omni CLI. Use this skill whenever someone wants to build a dashboard, create a workbook or document, add tiles or charts, configure dashboard filters or controls, set up a KPI view, lay out or rearrange tiles and pages, edit a dashboard as a draft and publish it, change dashboard settings, rename/move/duplicate/delete a dashboard, modify dashboard-level model customizations like workbook-specific joins or fields, or build and edit an Omni app (custom HTML content in place of a dashboard) — including casual phrasings like "make a dashboard for…", "add a chart to…", or "clean up this dashboard's layout" that don't name the skill. For running a query or pulling metrics use omni-query; for adding a field to the shared model use omni-model-builder.
 ---
 
 # Omni Content Builder
 
-Create, update, and manage Omni documents and dashboards programmatically via the Omni CLI — document lifecycle, drafts, workbook models, filters, controls, and dashboard content.
+Create, update, and manage Omni documents, dashboards, and apps programmatically via the Omni CLI — document lifecycle, drafts, workbook models, filters, controls, and dashboard content.
 
 > **Tip**: Use `omni-model-explorer` to understand available fields and `omni-content-explorer` to find existing dashboards to modify or learn from.
 

--- a/skills/omni-content-builder/references/documents-v2.md
+++ b/skills/omni-content-builder/references/documents-v2.md
@@ -1,6 +1,6 @@
 # Documents v2 API Reference
 
-The `omni documents v2-*` commands are the **only** surface for creating, reading, and editing documents — an explicit envelope of `queryPresentations`, `controls`, `containers`, and `settings`, edited through a **draft → publish** flow. Never fall back to the v1 `documents create`/`get`/`put`/`update` path. A few document-management operations (list, delete, move, duplicate, discard-draft, get-queries, downloads) have no v2 form and are the only command for that job — see the command list in [SKILL.md](../SKILL.md). Always read your result back with `v2-get` / `v2-get-draft` and verify.
+The `omni documents v2-*` commands are the **only** surface for creating, reading, and editing documents — an explicit envelope of `queryPresentations`, `controls`, `containers`, and `settings`, edited through a **draft → publish** flow. Never fall back to the v1 `documents create`/`get` path (v1 `put`/`update` were removed in CLI 1.2.2). A few document-management operations (list, delete, move, duplicate, discard-draft, get-queries, downloads) have no v2 form and are the only command for that job — see the command list in [SKILL.md](../SKILL.md). Always read your result back with `v2-get` / `v2-get-draft` and verify.
 
 ## Commands
 
@@ -105,6 +105,29 @@ column_totals{}, row_totals{}, fill_fields[], userEditedSQL
 ```
 
 All but `limit` and `join_paths_from_topic_name` are schema-required — omitting any of those returns a 400 listing each missing field. Send `limit` and `join_paths_from_topic_name` anyway: an unbounded query and broken topic joins are worse than a 400. `join_paths_from_topic_name` is the **topic name** (e.g. `"orders"`), not the base view name. Do **not** include `modelId` or `model_extension_id` (see above).
+
+## Apps (alpha, CLI ≥ 1.2.2)
+
+An **app** is HTML content in place of a dashboard. A document carries at most one of a dashboard or an app — never both; workbook-only is valid. The HTML and its `settings` live only at the app commands below; `v2-get` carries an `app` slice that points here and accepts it back only as it was read.
+
+| Command | Purpose |
+|---|---|
+| `v2-get-app <identifier>` | Read the published HTML + `settings` |
+| `v2-get-draft-app <identifier> <draftIdentifier>` | Read a named draft's app |
+| `v2-get-main-draft-app <identifier>` | Read the main draft's app (404 if there is no main draft) |
+| `v2-put-app <identifier> <draftIdentifier>` | Replace the HTML on a draft, creating the app if the draft is workbook-only |
+| `v2-patch-app <identifier> <draftIdentifier>` | Apply `htmlEdits` (substring search/replace) without resending the HTML |
+| `v2-remove-app <identifier> <draftIdentifier>` | Drop the app, leaving a workbook-only document |
+| `v2-put-app-auto-draft` / `v2-patch-app-auto-draft` `<identifier>` | The same two writes, creating-or-reusing the main draft in one call |
+
+- Create an app document with `omni documents v2-create <SHARED_MODEL_ID> "My App" --body '{"app": {"html": "…"}}'` — `model-id` and `name` are still required, and the `app` slice is mutually exclusive with `containers`, `controls`, and `settings`. Creation is gated on the org app toggle, and a user-scoped key needs the role's `allowCreateApps` on the model (or on its parent SHARED model) — otherwise a bare 403.
+- Writes are draft-only and never auto-publish. `v2-publish-draft` publishes the **main** draft only, so an app written to a branch-bound draft goes live through the branch merge instead (see [branch-bound-drafts.md](branch-bound-drafts.md)).
+- `PUT` creates the app; `PATCH` never does. The two PATCH variants differ on what they check: `v2-patch-app` 409s against a draft with no app, while `v2-patch-app-auto-draft` 409s when the **document has no published app** — so the create-then-edit-before-first-publish path must use `v2-patch-app`, not the auto-draft form.
+- `PUT` is last-write-wins with no version precondition. `PATCH`'s `htmlEdits` are all-or-nothing and content-addressed: an edit matching zero times, or more than once without `replaceAll`, rejects the whole request. That catches a **stale read**, not a concurrent writer — serialize writes to one app when it matters.
+- **Writes never reject on host policy.** An external `<script src>` / `<link rel="stylesheet">` host outside the org's app policy comes back as a non-blocking `warnings` entry on an otherwise-200 response, and the render-time CSP leaves it inert until an admin allows the host — so a CDN-loading app can "succeed" and render blank. Read `warnings` before reporting success.
+- HTML is capped at **2 MiB** on write; apps saved before the cap can read back larger and then fail on the way back in.
+- A dashboard document can't become an app in place — drop the dashboard first (`v2-remove-dashboard <identifier> <draftIdentifier>`), since a draft carrying a dashboard can never carry an app. Also avoid naming a draft `app`: the route ranks that literal above `{draftIdentifier}`, making the draft unaddressable on these commands.
+- Alpha — the app sub-resource may change shape without a deprecation cycle. Run `--help` / `--schema` on the command before your first write.
 
 ## Behaviors to design around
 

--- a/skills/omni-model-builder/SKILL.md
+++ b/skills/omni-model-builder/SKILL.md
@@ -60,6 +60,8 @@ Use dialect-appropriate functions in your SQL (e.g. `SAFE_DIVIDE` for BigQuery, 
 
 > **Creating a *new* SHARED model (rare).** Most work is on an existing model — but if you do create one with `omni models create`, the body is `{ modelKind: "SHARED", connectionId }` (no `baseModelId`; it inherits the connection's schema views + assumed relationships — run `omni models create --schema` for the full field list). **Footgun: create takes `modelName`, update takes `name`.** Passing `name` on create is silently ignored and the model is named from the connection — then you'd have to `omni models update <id> --body '{"name":"…"}'` to fix it. Pass **`modelName`** on create and skip the rename.
 
+> **Deleting a model (CLI ≥ 1.2.2).** `omni models delete <modelId>` trashes a SHARED or shared-extension model **together with the workbooks, dashboards, and child extension models built on it** — confirm that blast radius with the user before running it. Requires **Connection Admin**. It does not delete branches: use `omni models delete-branch` for those.
+
 ## Schema Refresh: Syncing with Database Changes
 
 The **schema layer** is auto-generated from your database. When your database schema changes (new/deleted/renamed columns, type changes), refresh it to stay in sync: `omni models refresh <modelId>` (add `--branch-id <branchId>` to scope to a branch; requires **Connection Admin**).

--- a/skills/omni-query/SKILL.md
+++ b/skills/omni-query/SKILL.md
@@ -426,6 +426,7 @@ Before presenting an async job answer, inspect the `actions[]` entries. A job ca
 Additional job commands:
 - `omni ai job-cancel <jobId>` — cancel a running job
 - `omni ai job-visualization <jobId>` — get the visualization output
+- `omni ai job-feedback-submit <jobId> --body '{"rating":"good"}'` — record a thumbs up/down on a finished job (CLI ≥ 1.2.2). `rating` is **required** (`good` / `bad`); `comment` is optional free text. Only once the poll reports `COMPLETE`/`FAILED` — any other state is a 409. Append-only and never read back, so submit once per job. With an org-scoped key, pass `--user-id` to attribute the feedback to the user the job was submitted with.
 
 ### Using Job Results in a Dashboard
 

--- a/skills/omni-query/references/job-result-to-presentation.md
+++ b/skills/omni-query/references/job-result-to-presentation.md
@@ -1,6 +1,6 @@
 # Job Result → queryPresentation Transformation
 
-Converts an `omni ai job-submit` result into a `queryPresentation` object suitable for use in `omni documents create` or a dashboard PUT.
+Converts an `omni ai job-submit` result into a `queryPresentation` object suitable for use in `omni documents v2-create` or a `v2-patch-draft` body.
 
 ## Why transformation is required
 


### PR DESCRIPTION
## What

Syncs the skills with Omni CLI **v1.2.2**, and with v1.2.1, which had not yet been synced.

| | |
|---|---|
| **Added (1.2.2)** | App sub-resource on documents v2 (alpha) — 8 commands (`v2-get-app`, `v2-get-draft-app`, `v2-get-main-draft-app`, `v2-put-app`, `v2-patch-app`, `v2-remove-app`, and the two `-auto-draft` variants) plus an `app` slice on `v2-create` |
| | `models delete`, `ai job-feedback-submit` |
| **Removed (1.2.2)** | `documents update` / `documents put` — the v1 `PATCH`/`PUT /api/v1/documents/{identifier}` endpoints no longer exist |
| **Added (1.2.1)** | `omni update check` |

## Approach

The 1.2.2 `--help` output carries the full contract for these commands, so the skills don't restate it. The new Apps section in `references/documents-v2.md` is a command table plus the cross-cutting rules an agent needs *before* it knows to run `--help`, weighted toward behaviors that fail quietly:

- **Writes never reject on host policy.** An external `<script src>` / `<link rel="stylesheet">` host outside the org's app policy returns a non-blocking `warnings` entry on an otherwise-200 response, and the render-time CSP leaves it inert — so an app loading a disallowed CDN host can report success and render blank. Read `warnings` before reporting success.
- **The two PATCH variants gate differently.** `v2-patch-app` returns 409 for a draft with no app; `v2-patch-app-auto-draft` returns 409 when the *document* has no **published** app. Create-then-edit-before-first-publish must therefore use `v2-patch-app`.
- `PUT` is last-write-wins; `PATCH`'s `htmlEdits` are all-or-nothing and content-addressed, which detects a stale read but is **not** concurrency safety.
- Creation gates (org app toggle, the role's `allowCreateApps`) otherwise surface as a bare 403. Plus the 2 MiB HTML cap, the dashboard-XOR-app rule, and `v2-remove-dashboard` as the conversion path.

Apps are also named in `omni-content-builder`'s description so that "build me an Omni app" reaches the skill.

## Removed v1 commands

Three places instructed agents to "never fall back to v1 `create`/`get`/`put`/`update`". Since `put` and `update` no longer exist, naming them as a fallback is worse than omitting them; they're dropped from those lists and the surrounding guidance is unchanged. `omni-query`'s `references/job-result-to-presentation.md` now points at `v2-create` / `v2-patch-draft`.

## Verification

Every command, argument order, body shape, and error code documented here was checked against the released 1.2.2 binary with `--help` and `--schema`.

Plugin versions bumped 1.9.1 → 1.10.0 across the four manifests. `omni-integrations` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbKX7EdhAcQpXCGCYBdP3N
