### PR TITLE
ci: make the CLI sync workflow fire, and extract its procedure into an agent

### DIFF
--- a/.claude/agents/sync-cli-changes.md
+++ b/.claude/agents/sync-cli-changes.md
@@ -1,0 +1,82 @@
+---
+name: sync-cli-changes
+description: Sync this repo's skills, agents, and rules with a new Omni CLI release. Use when a new exploreomni/cli version ships and the documented command surface may have drifted.
+---
+
+# Omni CLI Sync
+
+You bring the skills, agents, and rules in this repo back in line with a newly
+released Omni CLI. You are run from `.github/workflows/sync-cli-changes.yml`,
+and can also be invoked by hand during a release.
+
+The released binary is installed on the runner. **It is the source of truth** —
+release notes and diffs tell you where to look, but every claim you write must
+be confirmed with `omni … --help` or `omni … --schema`.
+
+## Procedure
+
+1. **Inventory the live surface.** Walk the command tree with `--help` and
+   collect every leaf command. Diff that against what the repo documents
+   (`grep -rhoE '\bomni [a-z0-9-]+( [a-z0-9-]+)?' --include='*.md' --include='*.mdc' skills rules agents README.md CONTRIBUTING.md AGENTS.md`).
+   Root-level docs carry `omni …` references too, and the verification gate below
+   covers every file.
+   You are looking for three things, in priority order:
+   - **Removed commands the repo still references.** These are the urgent ones:
+     following them produces a 404 or an "unknown command".
+   - **New commands worth documenting.** Not every new command needs a mention;
+     see *What to write* below.
+   - **Changed shapes** — renamed flags, new required fields, changed defaults.
+2. **Read the release notes and the PRs behind them** (`gh release view <tag>
+   --repo exploreomni/cli`, then the linked PRs) to learn intent — which change
+   is the feature and which merely rides along.
+3. **Verify every claim against the binary.** `--schema` gives required fields
+   and enum values; `--help` carries the behavioral contract. Never document a
+   body shape you have not seen in `--schema`.
+4. **Write the docs.** See below.
+5. **Add a CHANGELOG entry** under a new version heading, matching the style of
+   the entries above it, and bump the version in the manifests listed in
+   CONTRIBUTING.md → *Versioning*.
+6. **Open the PR** on the branch the workflow passes you, with the title it
+   gives you.
+
+## What to write
+
+**Defer to `--help`.** Omni CLI help text carries the full contract for each
+command, generated from the API spec. Do not restate it. A skill should carry
+what an agent needs *before* it knows to run `--help`: that the command exists,
+where it fits in a workflow, and the behaviors that fail quietly.
+
+Weight your writing toward failure modes that do not announce themselves — a
+write that returns 200 and silently does nothing, an error code that means
+something different than it appears to, a value that must not be cached. A
+caveat an agent would discover on its own from a clear error message is not
+worth a line.
+
+**Fix references to removed commands rather than annotating them.** When a
+command is gone, drop it from the prose. Naming a nonexistent command — even to
+warn against it — leaves a reader with a plausible-looking option that does not
+exist.
+
+**Skills that gain a new capability may need their description updated**, since
+that is what routes a request to the skill. Flag this in the PR rather than
+guessing: description edits move which requests reach the skill.
+
+## Verification before you open the PR
+
+- Every command name and argument order appears in `omni <command> --help`.
+- Every documented body field appears in `omni <command> --schema`.
+- No file still references a command that no longer exists.
+- Markdown is intact: table separator rows, closed code fences, working relative links.
+
+## Writing the PR
+
+**This repository is public.** Write the PR body as a technical description:
+what changed in the CLI, what changed here, and what a reviewer should look at.
+
+Keep out of it: your own review process and corrections, open questions for the
+maintainer, repo hygiene problems you noticed, and anything casting doubt on
+previously published release notes. Raise those in the PR *thread* or in an
+issue, not in the description.
+
+If you find repo problems unrelated to the sync, leave them out of the diff and
+mention them in a comment on the PR.

--- a/.github/workflows/sync-cli-changes.yml
+++ b/.github/workflows/sync-cli-changes.yml
@@ -1,18 +1,27 @@
 name: Sync CLI Changes to Skills
 
 on:
+  # Preferred trigger: exploreomni/cli dispatches on release.
   repository_dispatch:
     types: [cli-update]
+  # Fallback: poll for a release the repo has not synced yet, so a missed
+  # dispatch delays the sync by a day instead of dropping it.
+  schedule:
+    - cron: "17 13 * * *"
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "exploreomni/cli release tag to process (e.g. v1.2.3)"
-        required: true
+        description: "exploreomni/cli release tag to sync (e.g. v1.2.3). Leave empty for the latest release."
+        required: false
         type: string
 
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: sync-cli-changes
+  cancel-in-progress: false
 
 jobs:
   sync:
@@ -20,74 +29,172 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Tag values reach the shell through the environment, never through
+      # ${{ }} interpolation into a script body.
       - name: Resolve release tag
         id: release
-        run: |
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "tag=${{ github.event.client_payload.release_tag }}" >> "$GITHUB_OUTPUT"
-            echo "commit=${{ github.event.client_payload.commit_sha }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Fetch CLI changes since previous release
         env:
           GH_TOKEN: ${{ secrets.CLI_REPO_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TAG: ${{ github.event.client_payload.release_tag }}
+          INPUT_TAG: ${{ inputs.release_tag }}
         run: |
-          TAG="${{ steps.release.outputs.tag }}"
-          # Get the previous release tag
-          PREV_TAG=$(gh release list --repo exploreomni/cli --limit 2 --json tagName --jq '.[1].tagName // empty')
-          if [ -n "$PREV_TAG" ]; then
-            gh api repos/exploreomni/cli/compare/${PREV_TAG}...${TAG} --jq '.commits, .files' > /tmp/cli-release-diff.json
-            # Also get the full diff
-            gh api repos/exploreomni/cli/compare/${PREV_TAG}...${TAG} -H "Accept: application/vnd.github.v3.diff" > /tmp/cli-release-diff.txt
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            repository_dispatch) TAG="$DISPATCH_TAG" ;;
+            workflow_dispatch)   TAG="${INPUT_TAG:-}" ;;
+            *)                   TAG="" ;;
+          esac
+          if [ -z "$TAG" ]; then
+            # Drafts publish no assets (the download below would fail); pre-releases
+            # would sync the skills to a CLI that was never actually released.
+            TAG=$(gh release list --repo exploreomni/cli --limit 1 \
+              --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName')
+          fi
+          # This value names a branch and a git tag below, and is written to
+          # GITHUB_OUTPUT — so it must be anchored, not merely prefix-matched.
+          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+)*([-.][A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Unexpected release tag: $TAG"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "branch=sync/cli-$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag: $TAG"
+
+      # A release that needs no skill changes produces no branch and no PR, so a
+      # PR check alone would let the daily poll re-run it every day until the next
+      # release. The marker tag below records "this tag was considered", whether or
+      # not it resulted in a PR.
+      - name: Skip tags already synced
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.release.outputs.branch }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          MARKER="cli-synced/$TAG"
+          if git ls-remote --exit-code --tags origin "refs/tags/$MARKER" >/dev/null 2>&1; then
+            echo "$MARKER exists — $TAG has already been through a sync run."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          EXISTING=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state all \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already covers $TAG — nothing to do."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
           else
-            # First release — diff against the commit
-            echo "First release, no previous tag to compare" > /tmp/cli-release-diff.txt
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Pinned to the release being synced. install.sh always fetches the latest
+      # release, which would install the wrong binary when re-running an older tag.
+      - name: Install the released CLI
+        if: steps.guard.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CLI_REPO_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" --repo exploreomni/cli \
+            --pattern 'omni_*_linux_amd64.tar.gz' --output /tmp/omni.tar.gz --clobber
+          tar -xzf /tmp/omni.tar.gz -C /tmp omni
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 /tmp/omni "$HOME/.local/bin/omni"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
+          # The agent verifies every claim against this binary, so a version
+          # mismatch here would silently produce docs for the wrong release.
+          INSTALLED="v$(omni --version | awk '{print $NF}')"
+          echo "Installed $INSTALLED"
+          [ "$INSTALLED" = "$TAG" ] || { echo "::error::Installed $INSTALLED but syncing $TAG"; exit 1; }
+
+      - name: Fetch CLI changes since the previous release
+        if: steps.guard.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CLI_REPO_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # The release immediately before TAG — not simply the second-newest,
+          # which would diff the wrong range when re-running for an older tag.
+          gh release list --repo exploreomni/cli --limit 100 \
+            --exclude-drafts --exclude-pre-releases --json tagName --jq '.[].tagName' > /tmp/cli-tags.txt
+          # Releases list newest-first, so the line after TAG is the one before it.
+          # `|| true` because grep exits 1 when TAG falls outside the 100-release
+          # window, which pipefail would otherwise turn into a bare step failure.
+          PREV_TAG=$(grep -A1 -x -F "$TAG" /tmp/cli-tags.txt | tail -n +2 | head -1 || true)
+          if [ -n "${PREV_TAG:-}" ]; then
+            echo "Diffing $PREV_TAG...$TAG"
+            gh api "repos/exploreomni/cli/compare/${PREV_TAG}...${TAG}" --jq '.commits, .files' > /tmp/cli-release-diff.json
+            gh api "repos/exploreomni/cli/compare/${PREV_TAG}...${TAG}" \
+              -H "Accept: application/vnd.github.v3.diff" > /tmp/cli-release-diff.txt
+          else
+            echo "No release before $TAG to compare against" > /tmp/cli-release-diff.txt
             echo "[]" > /tmp/cli-release-diff.json
           fi
-          # Fetch release notes
           gh release view "$TAG" --repo exploreomni/cli --json tagName,name,body > /tmp/cli-release-meta.json
 
       - uses: anthropics/claude-code-action@bbfaf8e1ffe3e688f7ab65ceee78de241e24a238 # v1
+        if: steps.guard.outputs.proceed == 'true'
         id: sync
         with:
           use_claude_code_app: true
           direct_prompt: |
-            Release ${{ steps.release.outputs.tag }} was published in the exploreomni/cli repo.
+            Omni CLI release ${{ steps.release.outputs.tag }} was published.
 
-            The diff since the previous release is at /tmp/cli-release-diff.txt and
-            release metadata at /tmp/cli-release-meta.json.
+            Follow the procedure in `.claude/agents/sync-cli-changes.md` to bring this
+            repo's skills, agents, and rules back in line with it.
 
-            Your task: determine whether any files in this repo need updating to match the CLI changes.
+            Inputs on this runner:
+            - The released CLI is installed and on PATH — `omni --help` / `--schema` are
+              the source of truth for every claim you write.
+            - /tmp/cli-release-diff.txt — diff since the previous release
+            - /tmp/cli-release-meta.json — release notes
 
-            This repo contains Omni Analytics skill definitions (.md), agent instructions (.md),
-            and rule files (.mdc) that include CLI command examples, parameter tables, and
-            instructional prose. When the CLI changes — new shorthand syntax, new commands,
-            renamed flags, changed defaults — these docs must be updated to match.
+            If changes are needed, commit them to the branch
+            `${{ steps.release.outputs.branch }}` and open a PR titled
+            "Sync skills with exploreomni/cli@${{ steps.release.outputs.tag }}".
 
-            Steps:
-            1. Read /tmp/cli-release-diff.txt and /tmp/cli-release-meta.json to understand what changed
-            2. Search ALL .md and .mdc files for references to affected commands (grep broadly)
-            3. Update code examples, parameter tables, prose descriptions, and batch scripts
-            4. Also update surrounding prose that references old parameter names (e.g. "Set `runQuery: false`" should become "Pass `--run-query false`")
-            5. Verify markdown formatting — table separator rows, code fences, no duplicate headers
-            6. Do a final pass: grep again for any remaining stale references you missed
+            If nothing in this repo is affected by the release, make no changes and
+            open no PR.
 
-            If changes were made, commit them to a new branch and create a PR titled:
-            "Sync skills with exploreomni/cli@${{ steps.release.outputs.tag }}"
-
-            The PR body should list each file changed and summarize what was updated.
-
-            If no files in this repo reference the changed commands, exit without making changes.
-
-      - name: Trigger review on created PR
-        if: steps.sync.outcome == 'success'
+      - name: Request review on the new PR
+        if: steps.guard.outputs.proceed == 'true' && steps.sync.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # skill-review.yml triggers on issue_comment, and GitHub does not start
+          # workflow runs from events created with GITHUB_TOKEN. Commenting with it
+          # would post the comment and silently never trigger a review, so this
+          # needs its own token.
+          GH_TOKEN: ${{ secrets.SYNC_REVIEW_TOKEN || secrets.GITHUB_TOKEN }}
+          HAVE_REVIEW_TOKEN: ${{ secrets.SYNC_REVIEW_TOKEN != '' }}
+          BRANCH: ${{ steps.release.outputs.branch }}
         run: |
-          # Find the PR that was just created by the sync step
-          PR_NUMBER=$(gh pr list --repo ${{ github.repository }} --head "claude-sync-" --json number --jq '.[0].number // empty')
-          if [ -n "$PR_NUMBER" ]; then
-            gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} --body "/review"
+          set -euo pipefail
+          # --head matches a branch name exactly, so this must be the same
+          # branch name handed to the agent above.
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" \
+            --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR on $BRANCH — the release needed no skill changes."
+            exit 0
           fi
+          if [ "$HAVE_REVIEW_TOKEN" != "true" ]; then
+            echo "::warning::SYNC_REVIEW_TOKEN is not set — commenting /review with GITHUB_TOKEN would not trigger skill-review.yml. Comment /review on PR #$PR_NUMBER by hand."
+            exit 0
+          fi
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "/review"
+
+      # Recorded whether or not a PR was opened, so a release needing no skill
+      # changes is not reconsidered by tomorrow's poll.
+      - name: Mark this tag as synced
+        if: steps.guard.outputs.proceed == 'true' && steps.sync.outcome == 'success'
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "cli-synced/$TAG"
+          git push origin "refs/tags/cli-synced/$TAG"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
-.claude/
+# Local Claude Code settings stay out of the repo, but shared maintenance
+# agents under .claude/agents/ are versioned.
+.claude/*
+!.claude/agents/
 __pycache__/
 *.py[cod]
 # Eval run artifacts — never commit. Transcripts and raw outputs can capture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,55 @@ skills/<skill-name>/evals/evals.json
 
 Use the shared eval instance setup in `evals/SETUP.md` when a case depends on mutable Omni fixtures.
 
+## Staying in Sync with the Omni CLI
+
+The skills document CLI commands, so a CLI release can silently invalidate
+them — a removed command leaves prose pointing at something that now 404s, and
+a new command leaves agents working around a gap that has since been filled.
+
+`.github/workflows/sync-cli-changes.yml` handles this. It runs the procedure in
+`.claude/agents/sync-cli-changes.md` against a release, installs that release's
+binary on the runner, and opens a sync PR if anything in the repo is affected.
+
+It is triggered three ways:
+
+| Trigger | When |
+|---|---|
+| `repository_dispatch` (`cli-update`) | Preferred — `exploreomni/cli` dispatches on release |
+| `schedule` (daily) | Fallback — picks up a release whose dispatch never arrived |
+| `workflow_dispatch` | Manual, for a specific tag or to re-run a sync |
+
+The daily poll exists because the dispatch is a cross-repo dependency that can
+break silently on either side; without it, a missed dispatch means the drift is
+only found when someone hits a stale command. After each run the workflow pushes
+a `cli-synced/<tag>` marker tag, and skips any tag that already has one — a
+release needing no skill changes produces no PR, so a PR check alone would let
+the poll reconsider it every day.
+
+Two repository secrets back it:
+
+| Secret | Used for |
+|---|---|
+| `CLI_REPO_TOKEN` | Reading releases and diffs from `exploreomni/cli` |
+| `SYNC_REVIEW_TOKEN` | Commenting `/review` on the sync PR |
+
+`SYNC_REVIEW_TOKEN` is needed because `skill-review.yml` triggers on
+`issue_comment`, and GitHub does not start workflow runs from events created
+with the built-in `GITHUB_TOKEN`. Commenting with the default token posts the
+comment and silently triggers nothing. If the secret is unset, the workflow
+skips the comment and logs a warning naming the PR to review by hand, rather
+than appearing to have requested a review that never runs.
+
+To run a sync by hand, install the release you are syncing to and follow
+`.claude/agents/sync-cli-changes.md`. The installed binary is the source of
+truth: verify every command with `--help` and every body shape with `--schema`
+before documenting it. Release notes tell you where to look, not what is true.
+
+`.claude/agents/` holds maintenance agents. The marketplace entry installs from
+the repo root, so these files travel with the plugin, but Claude Code loads a
+plugin's user-facing agents from `agents/` — so they are not loaded as agents for
+plugin users, and are not counted in the plugin description.
+
 ## Versioning and Changelog
 
 Bump the affected plugin version when a user who already has the plugin installed would get different behavior after updating.

--- a/README.md
+++ b/README.md
@@ -314,6 +314,18 @@ Or update manually from the `/plugin` menu.
 
 Re-run the installation command or re-copy the updated `skills/` folders to pull the latest version.
 
+### How These Skills Track the Omni CLI
+
+These skills document a moving target: the Omni CLI ships new commands, and
+occasionally removes them. When a CLI release changes the command surface, a
+maintenance agent re-checks the skills against the newly released binary and
+opens a sync PR — so an updated plugin describes the CLI you actually have.
+
+Sync releases are recorded in `CHANGELOG.md`, naming the CLI version each one
+covers. If you are running a newer CLI than the most recent sync, some commands may not
+be documented here yet; `omni <command> --help` and `--schema` are authoritative
+in that gap. `omni update check` reports whether your CLI itself is current.
+
 ### Getting the Latest Version
 
 If your skills appear outdated, or the install command reports the plugin is "already installed" while skills aren't loading, your IDE may be serving a cached version. This can happen when the uninstall process doesn't fully clean up all registry and cache entries.
@@ -364,6 +376,9 @@ To ensure you're running the latest version, manually clear the stale plugin dat
 
 ```
 omni-agent-skills/
+├── .claude/
+│   └── agents/
+│       └── sync-cli-changes.md   # maintenance agent, not loaded for plugin users
 ├── .claude-plugin/
 │   ├── marketplace.json
 │   └── plugin.json


### PR DESCRIPTION
## Why

`sync-cli-changes.yml` has never run. It triggers only on a `repository_dispatch` from `exploreomni/cli` that does not arrive, so CLI releases 1.2.1 and 1.2.2 both went unsynced until the drift was found by hand (#99).

## Triggers

| Trigger | Role |
|---|---|
| `repository_dispatch` (`cli-update`) | Fast path, unchanged |
| `schedule` (daily) | **New** — picks up a release whose dispatch never arrived |
| `workflow_dispatch` | Now defaults to the latest release instead of requiring a tag |

After each run the workflow pushes a `cli-synced/<tag>` marker tag and skips tags that already have one. A release needing no skill changes opens no PR, so a PR-existence check alone would let the daily poll reconsider it indefinitely.

## Fixes

- **`gh pr list --head` matches a branch name exactly, not as a prefix.** The lookup for `"claude-sync-"` never matched, so `/review` was never posted even on a successful run. The branch name is now pinned (`sync/cli-<tag>`) and shared between the agent prompt and the lookup.
- **`skill-review.yml` triggers on `issue_comment`, and GitHub does not start workflow runs from events created with `GITHUB_TOKEN`.** The comment would post and trigger nothing. Now uses `SYNC_REVIEW_TOKEN`, and when that secret is unset it warns with the PR number rather than appearing to have requested a review.
- **The previous-release lookup took the second-newest release** rather than the release preceding the tag being synced — the wrong diff range on any re-run of an older tag.
- **`grep` exits 1 when a tag falls outside the release window**, which `pipefail` turned into a bare step failure before the no-previous-release fallback could run.
- **Drafts and pre-releases are now excluded.** A draft publishes no assets and would fail the download every day; a pre-release would sync the skills to a CLI that was never released.
- **Release tags reached the shell through `${{ }}` interpolation**, one source being a dispatch payload. They now pass through the environment and are validated against an anchored pattern before naming a branch or tag.

## Verification on the runner

The workflow installs the release asset for the tag being synced rather than piping `install.sh`, which always fetches the *latest* release and would have installed the wrong binary when re-running an older tag. A version mismatch now fails the job: the agent verifies every claim against this binary, so the wrong one would quietly produce docs for the wrong release.

## Procedure

The inline prompt moves to `.claude/agents/sync-cli-changes.md`, so the procedure is versioned and reviewable, and can be followed by hand during a release. It covers inventorying the live command tree, verifying against `--help` / `--schema` rather than release notes, deferring to help text instead of restating it, and dropping references to removed commands rather than annotating them.

`.claude/agents/` is un-ignored so the file is versioned; `settings.local.json` and `worktrees/` stay ignored.

## Setup required

This needs a **`SYNC_REVIEW_TOKEN`** repository secret (a PAT or App token that can comment on PRs). Without it the workflow still runs and opens the sync PR — it just logs a warning instead of requesting review.

Docs: CONTRIBUTING.md gains a "Staying in Sync with the Omni CLI" section with the trigger table and both secrets; README.md gains "How These Skills Track the Omni CLI" and lists `.claude/agents/` in the structure tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbKX7EdhAcQpXCGCYBdP3N
