### PR TITLE
ci: never let the review comment cost the sync marker, and drop CLI_REPO_TOKEN

### DIFF
--- a/.github/workflows/sync-cli-changes.yml
+++ b/.github/workflows/sync-cli-changes.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Resolve release tag
         id: release
         env:
-          GH_TOKEN: ${{ secrets.CLI_REPO_TOKEN }}
+          # exploreomni/cli is public, so the built-in token can read its
+          # releases and diffs. Avoids depending on a PAT that expires silently.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_TAG: ${{ github.event.client_payload.release_tag }}
           INPUT_TAG: ${{ inputs.release_tag }}
@@ -93,7 +95,9 @@ jobs:
       - name: Install the released CLI
         if: steps.guard.outputs.proceed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.CLI_REPO_TOKEN }}
+          # exploreomni/cli is public, so the built-in token can read its
+          # releases and diffs. Avoids depending on a PAT that expires silently.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
@@ -113,7 +117,9 @@ jobs:
       - name: Fetch CLI changes since the previous release
         if: steps.guard.outputs.proceed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.CLI_REPO_TOKEN }}
+          # exploreomni/cli is public, so the built-in token can read its
+          # releases and diffs. Avoids depending on a PAT that expires silently.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
@@ -160,6 +166,20 @@ jobs:
             If nothing in this repo is affected by the release, make no changes and
             open no PR.
 
+      # Pushed before the review request, and never gated on it: the marker is
+      # what stops tomorrow's poll from redoing this sync, while the /review
+      # comment is a convenience. A failure there must not cost us the marker.
+      - name: Mark this tag as synced
+        if: steps.guard.outputs.proceed == 'true' && steps.sync.outcome == 'success'
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "cli-synced/$TAG"
+          git push origin "refs/tags/cli-synced/$TAG"
+
       - name: Request review on the new PR
         if: steps.guard.outputs.proceed == 'true' && steps.sync.outcome == 'success'
         env:
@@ -181,20 +201,12 @@ jobs:
             exit 0
           fi
           if [ "$HAVE_REVIEW_TOKEN" != "true" ]; then
-            echo "::warning::SYNC_REVIEW_TOKEN is not set — commenting /review with GITHUB_TOKEN would not trigger skill-review.yml. Comment /review on PR #$PR_NUMBER by hand."
+            echo "::warning::SYNC_REVIEW_TOKEN is not set. Comment /review on PR #$PR_NUMBER by hand."
             exit 0
           fi
-          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "/review"
-
-      # Recorded whether or not a PR was opened, so a release needing no skill
-      # changes is not reconsidered by tomorrow's poll.
-      - name: Mark this tag as synced
-        if: steps.guard.outputs.proceed == 'true' && steps.sync.outcome == 'success'
-        env:
-          TAG: ${{ steps.release.outputs.tag }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "cli-synced/$TAG"
-          git push origin "refs/tags/cli-synced/$TAG"
+          # The secret being present does not mean it works: a fine-grained token
+          # awaiting org approval is set but rejected. Never fail the job over it —
+          # the PR is already open, and the sync is already recorded above.
+          if ! gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "/review"; then
+            echo "::warning::SYNC_REVIEW_TOKEN was rejected (an org-approval-pending token looks like this). Comment /review on PR #$PR_NUMBER by hand."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,19 +133,26 @@ a `cli-synced/<tag>` marker tag, and skips any tag that already has one — a
 release needing no skill changes produces no PR, so a PR check alone would let
 the poll reconsider it every day.
 
-Two repository secrets back it:
+It needs one repository secret, `SYNC_REVIEW_TOKEN`, used only to comment
+`/review` on the sync PR. Reading `exploreomni/cli` needs no secret — the repo
+is public, so the built-in `GITHUB_TOKEN` covers it.
 
-| Secret | Used for |
-|---|---|
-| `CLI_REPO_TOKEN` | Reading releases and diffs from `exploreomni/cli` |
-| `SYNC_REVIEW_TOKEN` | Commenting `/review` on the sync PR |
-
-`SYNC_REVIEW_TOKEN` is needed because `skill-review.yml` triggers on
+`SYNC_REVIEW_TOKEN` is required because `skill-review.yml` triggers on
 `issue_comment`, and GitHub does not start workflow runs from events created
-with the built-in `GITHUB_TOKEN`. Commenting with the default token posts the
-comment and silently triggers nothing. If the secret is unset, the workflow
-skips the comment and logs a warning naming the PR to review by hand, rather
-than appearing to have requested a review that never runs.
+with `GITHUB_TOKEN`. Commenting with the default token posts the comment and
+silently triggers nothing.
+
+The review comment is best-effort and never fails the job: if the secret is
+unset, or set but rejected — a fine-grained token awaiting org approval looks
+exactly like this — the workflow logs a warning naming the PR to review by
+hand. The `cli-synced/<tag>` marker is pushed *before* the comment is
+attempted, so a review that could not be requested never costs the record of
+the sync having run.
+
+> **Fine-grained PATs expire.** `DOCS_REPO_TOKEN` (used by `notify-docs.yml`)
+> lapsed in early August 2026 and the workflow failed silently on every push
+> for a month. Prefer the built-in token wherever a repo is public, and when a
+> PAT is unavoidable, note its expiry.
 
 To run a sync by hand, install the release you are syncing to and follow
 `.claude/agents/sync-cli-changes.md`. The installed binary is the source of


### PR DESCRIPTION
Two failure modes found while setting up `SYNC_REVIEW_TOKEN`.

## A set secret is not a working secret

The presence check (`secrets.SYNC_REVIEW_TOKEN != ''`) passes for a fine-grained token that is set but still awaiting org approval. The API then rejects it, `set -e` fails the step, and because the marker step carries an implicit `success()` gate, the `cli-synced/<tag>` tag never gets pushed — so the next day's poll redoes the entire sync and opens a duplicate PR.

A best-effort convenience was able to take down the durable state that prevents duplicate work.

- The marker is now pushed **before** the review is requested, and is never gated on it.
- A rejected token is treated like an unset one: warn with the PR number to review by hand, and let the job succeed.

## `CLI_REPO_TOKEN` is very likely expired

| | |
|---|---|
| Both PATs created | 2026-04-09 |
| `notify-docs` last succeeded | 2026-07-24 |
| First failure | 2026-08-10, `Repository not found, OR token has insufficient permissions` |

That is a ~120-day fine-grained PAT expiry. `CLI_REPO_TOKEN` is the same vintage and has **never been exercised**, because this workflow had never run — tomorrow's scheduled poll would have been its first real use, failing on the first step.

`exploreomni/cli` is public, so `GITHUB_TOKEN` can read its releases and diffs. This drops the PAT dependency rather than renewing a token that expires silently again in four months.

## Not fixed here

`DOCS_REPO_TOKEN` still needs renewing — `notify-docs.yml` has been failing on every push to `main` for a month, including the merge of #100. That is a separate workflow and a credential only an admin can rotate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbKX7EdhAcQpXCGCYBdP3N
