### PR TITLE
chore: ignore `npx skills add` install artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 # agents under .claude/agents/ are versioned.
 .claude/*
 !.claude/agents/
+# `npx skills add` install artifacts. This repo publishes skills rather than
+# installing any, so a consumer lockfile and an installed copy of the skill tree
+# here only ever come from testing the install flow in a working checkout — they
+# pin this repo to itself and go stale silently.
+.agents/
+skills-lock.json
 __pycache__/
 *.py[cod]
 # Eval run artifacts — never commit. Transcripts and raw outputs can capture


### PR DESCRIPTION
Running `npx skills add exploreomni/omni-agent-skills` in a working checkout — the install flow documented in README.md — writes `skills-lock.json` and copies the skill tree into `.agents/skills/`.

Both landed in this repo untracked on 2026-08-20, and neither is meaningful here. This repo **publishes** skills rather than installing any, so the lockfile pins the repo to itself and records nothing.

They also go stale invisibly. Both still named the databricks skill `omni-to-databricks-metric-view`, renamed to `-metric-views` since, and the `.agents/` copy of `omni-content-builder` still described the v1 document commands the CLI removed in 1.2.2 — the exact guidance #99 corrects.

Untracked and unignored, they were one `git add -A` away from being committed, which is how `skills-lock.json` nearly shipped in #101.

Verified after the change: `.agents/` and `skills-lock.json` are ignored, `.claude/agents/` is still versioned, and `.claude/settings.local.json` is still ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbKX7EdhAcQpXCGCYBdP3N
