### PR TITLE
feat: single source of truth for the plugin version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Claude Code — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 4 context rules.",
-    "version": "1.9.1"
+    "version": "1.11.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.9.1",
+      "version": "1.11.0",
       "author": {
         "name": "Omni Analytics"
       },
@@ -44,7 +44,7 @@
       "name": "omni-integrations",
       "source": "./skills/omni-integrations",
       "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, and more.",
-      "version": "1.2.2",
+      "version": "1.11.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-analytics",
-  "version": "1.9.1",
+  "version": "1.11.0",
 
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
   "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Omni Analytics skills for Cursor — explore models, run queries, build dashboards, embed analytics, and manage your Omni instance. Includes 9 skills, 3 specialized agents, and 4 context rules.",
-    "version": "1.9.1"
+    "version": "1.11.0"
   },
   "plugins": [
     {
       "name": "omni-analytics",
       "source": "./",
       "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills, 3 specialized agents, and 4 context rules for model exploration, querying, model building, content browsing, content building, embedding, AI optimization, AI eval, and administration.",
-      "version": "1.9.1",
+      "version": "1.11.0",
       "author": {
         "name": "Omni Analytics"
       },
@@ -44,7 +44,7 @@
       "name": "omni-integrations",
       "source": "./skills/omni-integrations",
       "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
-      "version": "1.2.2",
+      "version": "1.11.0",
       "author": {
         "name": "Omni Analytics"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "omni-analytics",
 
-  "version": "1.9.1",
+  "version": "1.11.0",
   "description": "Explore, query, model, embed, and manage Omni Analytics through the REST API and embed SDK. Includes 9 skills for model exploration, querying, model building, content browsing, dashboard creation, embedding, AI optimization, AI eval, and administration — plus 3 specialized subagents and always-on rules for API conventions.",
   "author": {
     "name": "Omni Analytics",

--- a/.github/scripts/stamp_versions.py
+++ b/.github/scripts/stamp_versions.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Stamp the version from versions.json into every plugin manifest.
+
+versions.json is the single source of truth. Manifests are generated from it,
+so a PR changes one line instead of ten fields across six files.
+
+  stamp_versions.py            rewrite the manifests
+  stamp_versions.py --check    exit 1 if any manifest is out of date
+
+Edits are textual so that manifest formatting — which is hand-maintained and
+includes blank lines a JSON round-trip would discard — survives untouched.
+"""
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+MANIFESTS = [
+    ".claude-plugin/plugin.json",
+    ".cursor-plugin/plugin.json",
+    ".claude-plugin/marketplace.json",
+    ".cursor-plugin/marketplace.json",
+    "skills/omni-integrations/.claude-plugin/plugin.json",
+    "skills/omni-integrations/.cursor-plugin/plugin.json",
+]
+
+# Only a semver-shaped value is rewritten, so an unrelated "version" key
+# (a schema version, say) is never touched.
+VERSION_LINE = re.compile(r'("version"\s*:\s*)"\d+\.\d+\.\d+[^"]*"')
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def read_version() -> str:
+    data = json.loads((ROOT / "versions.json").read_text())
+    version = data["version"]
+    if not SEMVER.match(version):
+        sys.exit(
+            f"versions.json: {version!r} is not MAJOR.MINOR.PATCH. "
+            "All three components are required, e.g. 1.11.0 rather than 1.11."
+        )
+    return version
+
+
+def main() -> int:
+    check = "--check" in sys.argv
+    version = read_version()
+    stale = []
+
+    for rel in MANIFESTS:
+        path = ROOT / rel
+        before = path.read_text()
+        after, count = VERSION_LINE.subn(rf'\1"{version}"', before)
+        if not count:
+            sys.exit(f"{rel}: no version field found — has the manifest moved?")
+        if after == before:
+            continue
+        stale.append(rel)
+        if not check:
+            path.write_text(after)
+
+    if check and stale:
+        print(f"Manifests are not stamped at {version} from versions.json:")
+        for rel in stale:
+            print(f"  {rel}")
+        print("\nRun .github/scripts/stamp_versions.py to fix.")
+        return 1
+
+    print(f"{'Would stamp' if check else 'Stamped'} {version} "
+          f"({len(stale)} file(s) {'stale' if check else 'updated'})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -1,0 +1,59 @@
+name: Versions
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  # A PR may leave the manifests untouched — the stamp job below fills them in
+  # after merge. What it may not do is hand-write a version that disagrees with
+  # versions.json, which is how the ten fields drifted apart before.
+  guard:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Reject hand-edited versions
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD -- \
+            '.claude-plugin/*.json' '.cursor-plugin/*.json' \
+            'skills/omni-integrations/.claude-plugin/*.json' \
+            'skills/omni-integrations/.cursor-plugin/*.json')
+          if [ -z "$CHANGED" ]; then
+            echo "No manifest changes — versions.json alone is the way to bump."
+            exit 0
+          fi
+          echo "Manifests touched by this PR:"
+          echo "$CHANGED" | sed 's/^/  /'
+          echo
+          # Touching them is allowed, but only in agreement with versions.json.
+          python3 .github/scripts/stamp_versions.py --check
+
+  stamp:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Stamp manifests from versions.json
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/stamp_versions.py
+          if git diff --quiet; then
+            echo "Manifests already match versions.json."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- '*.json'
+          git commit -m "chore: stamp manifests from versions.json"
+          git push origin HEAD:main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Changelog tracking begins with the next release. Historical releases are not bac
 
 The versions documented here should match the published plugin versions in the affected manifest files.
 
+## [1.11.0] - 2026-09-10
+
+_Both plugins move to a single shared version with this release. They ship from
+the same repo at the same commit, so `omni-integrations` jumps from 1.2.2 to
+match. Entries below 1.11.0 use the old scheme, where the heading number belonged
+to whichever plugin that release was for — which is why version numbers there do
+not read in order._
+
+### omni-analytics
+
+**Changed**
+- **Versions now come from `versions.json`.** One line at the repo root is stamped into all ten version fields across the six manifests by CI on merge, so a release bump no longer conflicts with every other PR in flight. A `guard` check fails any PR that hand-writes a version disagreeing with the source of truth. See CONTRIBUTING.md → *Versioning and Changelog*.
+
+### omni-integrations
+
+**Changed**
+- Version realigned from 1.2.2 to the shared repo version. No functional change.
+
 ## [1.9.1] - 2026-09-03
 
 ### omni-analytics

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,12 +182,49 @@ Use semantic versioning:
 | New skills, new features, behavior changes | `MINOR` |
 | Breaking changes to existing skill behavior | `MAJOR` |
 
-Only bump the plugin whose behavior changed. A fix to `omni-integrations` does not require bumping `omni-analytics`.
+Always all three components: `1.11.0`, never `1.11`.
 
-Keep duplicated version metadata in sync:
+**CI does not infer the level.** Whether a change is a patch or a minor is a
+judgment about impact that only the author can make — a one-word edit to a skill
+`description` changes which requests reach that skill and is a `MINOR`, while a
+large rewrite that leaves behavior identical is a `PATCH`. Pick it with the table
+above; CI only propagates the number you chose.
 
-- `omni-analytics`: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, `.cursor-plugin/marketplace.json`
-- `omni-integrations`: `skills/omni-integrations/.claude-plugin/plugin.json`, `skills/omni-integrations/.cursor-plugin/plugin.json`, `.claude-plugin/marketplace.json` (`omni-integrations` entry), `.cursor-plugin/marketplace.json` (`omni-integrations` entry)
+### One version, one place
+
+`versions.json` at the repo root is the single source of truth:
+
+```json
+{ "version": "1.11.0" }
+```
+
+Bumping a release means editing that one line. On merge to `main`, the `stamp`
+job in `.github/workflows/versions.yml` writes it into all ten version fields
+across the six manifests and commits the result, so a PR carries its actual
+change rather than ten lines of bookkeeping that conflict with every other PR in
+flight.
+
+To stamp locally — never required, but handy before cutting a release:
+
+```bash
+.github/scripts/stamp_versions.py          # rewrite manifests
+.github/scripts/stamp_versions.py --check  # report drift, change nothing
+```
+
+A PR may leave the manifests alone entirely. What it may not do is hand-write a
+version that disagrees with `versions.json`: the `guard` job fails the PR if a
+manifest is touched and does not match. That is the check that keeps the ten
+fields from drifting apart again.
+
+**Both plugins share one version** as of 1.11.0. They ship from the same repo at
+the same commit — `omni-analytics` installs from the repo root and
+`omni-integrations` from a subdirectory of it — so two numbers described a
+release cadence that did not exist, and the changelog had already collapsed them
+into one heading per release. The visible cost is that `omni-integrations` now
+takes a version bump in releases where its own files did not change; the benefit
+is that a version identifies a commit of this repo, unambiguously. Entries before
+1.11.0 use the old scheme, where the heading number belonged to whichever plugin
+that release was for.
 
 Document user-visible changes in `CHANGELOG.md` under the affected version. Use `Added`, `Changed`, and `Fixed` sections. The date should be the release date, not necessarily the commit date.
 

--- a/skills/omni-integrations/.claude-plugin/plugin.json
+++ b/skills/omni-integrations/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-integrations",
-  "version": "1.2.2",
+  "version": "1.11.0",
   "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
   "author": {
     "name": "Omni Analytics",

--- a/skills/omni-integrations/.cursor-plugin/plugin.json
+++ b/skills/omni-integrations/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-integrations",
-  "version": "1.2.2",
+  "version": "1.11.0",
   "description": "Integration skills for connecting Omni Analytics with external data platforms — Snowflake Semantic Views, Databricks Metric Views, and more.",
   "author": {
     "name": "Omni Analytics",

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,4 @@
+{
+  "//": "Single source of truth for the plugin version. Both plugins ship from this repo at the same commit and share one version; see CONTRIBUTING.md.",
+  "version": "1.11.0"
+}


### PR DESCRIPTION
## Why

Ten version fields across six manifests had to be hand-edited in lockstep on every release — bookkeeping unrelated to the change a PR actually carries, and a conflict magnet whenever two PRs are in flight, since both edit the same lines in files neither is really changing.

## How

`versions.json` at the repo root holds the version:

```json
{ "version": "1.11.0" }
```

A release bump is that one line. Two jobs in `.github/workflows/versions.yml`:

- **`stamp`** (on merge to `main`) writes it into all ten fields and commits.
- **`guard`** (on PRs) fails if a manifest is touched *and* disagrees with `versions.json`. A PR that leaves the manifests alone passes — the stamp fills them in after merge.

That guard is the "don't hardcode versions" check: hand-editing a manifest to a version the source of truth doesn't agree with is exactly what let the ten fields drift apart before.

The stamper edits **textually** rather than round-tripping JSON, so the hand-maintained manifest formatting survives — `plugin.json` has a deliberate blank line after `version` that `json.dump` would eat. It only rewrites semver-shaped values, so an unrelated `"version"` key is never touched, and it errors rather than silently doing nothing if a manifest moves.

## Both plugins share one version

They ship from the same repo at the same commit — `omni-analytics` installs from the root, `omni-integrations` from a subdirectory of it — so two numbers described a release cadence that doesn't exist. The changelog had already collapsed them into one heading per release, which is why its versions don't read in order today:

```
## [1.9.1]  ← analytics
## [1.8.0]  ← analytics
## [1.7.0]  ← analytics
## [1.2.1]  ← integrations (!)
## [1.6.0]  ← analytics
```

`omni-integrations` moves 1.2.2 → 1.11.0 with no functional change. The visible cost is that it now takes a version bump in releases where its own files didn't change; the benefit is that a version identifies a commit of this repo, unambiguously.

## Choosing the level

CI does **not** infer patch vs minor — that's a judgment about impact only the author can make. A one-word edit to a skill `description` changes which requests reach that skill and is a `MINOR`; a large rewrite that leaves behavior identical is a `PATCH`. CONTRIBUTING keeps the existing table; CI only propagates the number you choose. All three components are required (`1.11.0`, never `1.11`) and the script rejects anything else.

## Merge order

Best merged **after #99**, so the 1.10.0 release lands under the old scheme and 1.11.0 is cleanly the first unified one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbKX7EdhAcQpXCGCYBdP3N
